### PR TITLE
fis-climate#1348: Add `assert_rendered_xls_matches` as a library method

### DIFF
--- a/webgrid/testing.py
+++ b/webgrid/testing.py
@@ -47,13 +47,13 @@ def assert_rendered_xls_matches(rendered_xls, xls_headers, xls_rows):
     the given parameters.
 
     NOTE: This method does not perform in-depth analysis of complex workbooks!
+          Assumes up to one row of headers, and data starts immediately after.
           Multiple worksheets or complex (multi-row) headers *are not verified!*
 
-    :param rendered_xls:
-    :param xls_headers:
-    :param xls_rows:
+    :param rendered_xls: binary data passed to xlrd as file_contents
+    :param xls_headers: iterable with length, represents single row of column headers
+    :param xls_rows: list of rows in order as they will appear in the worksheet
     :return:
-    :rtype: bool
     """
     assert rendered_xls
     workbook = xlrd.open_workbook(file_contents=rendered_xls)

--- a/webgrid/testing.py
+++ b/webgrid/testing.py
@@ -1,0 +1,96 @@
+"""
+A collection of utilities for testing webgrid functionality in client applications
+"""
+
+import xlrd
+
+
+def assert_list_equal(list1, list2):
+    """
+    A list-specific equality assertion.
+
+    This method is based on the Python `unittest.TestCase.assertListEqual` method.
+
+    :param list1:
+    :param list2:
+    :return:
+    """
+
+    # resolve generators
+    list1, list2 = map(list, (list1, list2))
+
+    assert len(list1) == len(list2), \
+        'Lists are different lengths: {} != {}'.format(
+            len(list1),
+            len(list2)
+    )
+
+    if list1 == list2:
+        # the lists are the same, we're done
+        return
+
+    # the lists are different in at least one element; find it
+    # and report it
+    for index, (val1, val2) in enumerate(zip(list1, list2)):
+        assert val1 == val2, (
+            'First differing element at index {}: {} != {}'.format(
+                index,
+                repr(val1),
+                repr(val2)
+            )
+        )
+
+
+def assert_rendered_xls_matches(rendered_xls, xls_headers, xls_rows):
+    """
+    Verifies that `rendered_xls` has a set of headers and values that match
+    the given parameters.
+
+    NOTE: This method does not perform in-depth analysis of complex workbooks!
+          Multiple worksheets or complex (multi-row) headers *are not verified!*
+
+    :param rendered_xls:
+    :param xls_headers:
+    :param xls_rows:
+    :return:
+    :rtype: bool
+    """
+    assert rendered_xls
+    workbook = xlrd.open_workbook(file_contents=rendered_xls)
+
+    assert workbook.nsheets >= 1
+    sheet = workbook.sheet_by_index(0)
+
+    # # verify the shape of the sheet
+
+    # ## shape of rows (1 row for the headers, 1 for each row of data)
+    nrows = len(xls_rows)
+    if xls_headers:
+        nrows += 1
+    assert nrows == sheet.nrows
+
+    # ## shape of columns
+    ncols = max(
+        len(xls_headers) if xls_headers else 0,
+        max(len(values) for values in xls_rows) if xls_rows else 0
+    )
+    assert ncols == sheet.ncols
+
+    if xls_headers:
+        assert_list_equal(
+            (cell.value for cell in sheet.row(0)),
+            xls_headers
+        )
+
+    if xls_rows:
+        row_iter = sheet.get_rows()
+
+        # skip header row
+        if xls_headers:
+            next(row_iter)
+
+        for row, expected_row in zip(row_iter, xls_rows):
+            assert_list_equal(
+                (cell.value for cell in row),
+                expected_row
+            )

--- a/webgrid/tests/test_testing.py
+++ b/webgrid/tests/test_testing.py
@@ -1,0 +1,138 @@
+from io import BytesIO
+
+import xlwt
+from nose.tools import assert_raises
+
+from webgrid import testing
+
+
+class TestAssertListEqual:
+    """Verify the `assert_list_equal` method performs as expected"""
+
+    def test_simple_equivalents(self):
+        testing.assert_list_equal([], [])
+        testing.assert_list_equal([1, 2, 3], [1, 2, 3])
+        testing.assert_list_equal((1, 2, 3), [1, 2, 3])
+        testing.assert_list_equal('123', '123')
+
+    def test_different_lengths(self):
+        with assert_raises(AssertionError):
+            testing.assert_list_equal([], [1])
+
+        with assert_raises(AssertionError):
+            testing.assert_list_equal([1], [])
+
+    def test_different_elements(self):
+        with assert_raises(AssertionError):
+            testing.assert_list_equal([1, 2, 3], [1, 2, 4])
+
+    def test_order_is_significant(self):
+        with assert_raises(AssertionError):
+            testing.assert_list_equal([1, 2, 3], [2, 3, 1])
+
+    def test_generators(self):
+        testing.assert_list_equal((x for x in range(3)), (x for x in range(3)))
+        testing.assert_list_equal((x for x in range(3)), [0, 1, 2])
+        testing.assert_list_equal([0, 1, 2], (x for x in range(3)))
+
+
+class TestAssertRenderedXlsMatches:
+    def setup(self):
+        self.workbook = xlwt.Workbook()
+        self.sheet = self.workbook.add_sheet('sheet1')
+        self.stream = BytesIO()
+
+        self.headers_written = False
+
+    def set_headers(self, headers):
+        for index, header in enumerate(headers):
+            self.sheet.write(0, index, header)
+
+        self.headers_written = True
+
+    def set_values(self, values):
+        row_offset = 0
+
+        if self.headers_written:
+            row_offset = 1
+
+        for row_index, row in enumerate(values, start=row_offset):
+            for col_index, value in enumerate(row):
+                self.sheet.write(row_index, col_index, value)
+
+    def assert_matches(self, xls_headers, xls_rows):
+        self.workbook.save(self.stream)
+        testing.assert_rendered_xls_matches(self.stream.getvalue(), xls_headers, xls_rows)
+
+    def test_empty_xls(self):
+        with assert_raises(AssertionError):
+            testing.assert_rendered_xls_matches(b'', None, None)
+
+        with assert_raises(AssertionError):
+            testing.assert_rendered_xls_matches(None, None, None)
+
+        with assert_raises(AssertionError):
+            testing.assert_rendered_xls_matches(None, [], [])
+
+    def test_blank_workbook(self):
+        self.assert_matches([], [])
+
+    def test_single_header(self):
+        self.set_headers(['Foo'])
+        self.assert_matches(['Foo'], [])
+
+    def test_multiple_headers(self):
+        self.set_headers(['Foo', 'Bar'])
+        self.assert_matches(['Foo', 'Bar'], [])
+
+    def test_single_row(self):
+        self.set_values([[1, 2, 3]])
+        self.assert_matches([], [[1, 2, 3]])
+
+    def test_multiple_rows(self):
+        self.set_values([
+            [1, 2, 3],
+            [2, 3, 4]
+        ])
+
+        self.assert_matches([], [
+            [1, 2, 3],
+            [2, 3, 4]
+        ])
+
+    def test_headers_and_rows(self):
+        self.set_headers(['Foo', 'Bar'])
+        self.set_values([
+            [1, 2],
+            [2, 3],
+            [3, 4]
+        ])
+
+        self.assert_matches(
+            ['Foo', 'Bar'],
+            [
+                [1, 2],
+                [2, 3],
+                [3, 4]
+            ]
+        )
+
+    def test_value_types(self):
+        self.set_values([
+            [1, 1.23, 'hello', None, True, False]
+        ])
+
+        self.assert_matches([], [
+            [1, 1.23, 'hello', '', True, False]
+        ])
+
+    def test_none_is_mangled(self):
+        self.set_values([
+            [None, 1, 1.23, 'hello', None]
+        ])
+
+        # the left `None` becomes an empty string
+        # the right `None` gets dropped
+        self.assert_matches([], [
+            ['', 1, 1.23, 'hello']
+        ])


### PR DESCRIPTION
Once this change makes it downstream, applications will be able to verify their rendered XLS by calling this library function, without having to implement their own custom assertion.

    from webgrid.testing import assert_rendered_xls_matches

    def test_something():
        xls = . . .
        assert_rendered_xls_matches(xls, ..., ...)