### PR TITLE
Handle None values for between operator of DateFilter

### DIFF
--- a/webgrid/filters.py
+++ b/webgrid/filters.py
@@ -711,6 +711,12 @@ class DateFilter(FilterBase, _DateMixin):
         return FilterBase.apply(self, query)
 
     def process(self, value, is_value2):
+        if value is None and self.op in (ops.between, ops.not_between):
+            if is_value2:
+                value = ''
+            else:
+                raise formencode.Invalid(gettext('invalid date'), value, self)
+
         if value is None or self.op in self.no_value_operators:
             return None
 

--- a/webgrid/tests/test_filters.py
+++ b/webgrid/tests/test_filters.py
@@ -327,6 +327,20 @@ class TestDateFilter(CheckFilterBase):
             "WHERE persons.due_date BETWEEN '2010-12-31' AND '{}'".format(today)
         )
 
+    def test_between_none_date(self):
+        filter = DateFilter(Person.due_date)
+        filter.set('between', '12/31/2010')
+        today = dt.date.today().strftime('%Y-%m-%d')
+        self.assert_filter_query(
+            filter,
+            "WHERE persons.due_date BETWEEN '2010-12-31' AND '{}'".format(today)
+        )
+
+        with assert_raises(formencode.Invalid):
+            filter.set('between', None)
+        eq_(filter.error, True)
+        eq_(filter.description, 'invalid')
+
     def test_between_blank(self):
         filter = DateFilter(Person.due_date)
         with assert_raises(formencode.Invalid):
@@ -342,6 +356,20 @@ class TestDateFilter(CheckFilterBase):
             filter,
             "WHERE persons.due_date NOT BETWEEN '2010-12-31' AND '{}'".format(today)
         )
+
+    def test_not_between_none_date(self):
+        filter = DateFilter(Person.due_date)
+        filter.set('!between', '12/31/2010')
+        today = dt.date.today().strftime('%Y-%m-%d')
+        self.assert_filter_query(
+            filter,
+            "WHERE persons.due_date NOT BETWEEN '2010-12-31' AND '{}'".format(today)
+        )
+
+        with assert_raises(formencode.Invalid):
+            filter.set('!between', None)
+        eq_(filter.error, True)
+        eq_(filter.description, 'invalid')
 
     def test_not_between(self):
         filter = DateFilter(Person.due_date)


### PR DESCRIPTION
* Add test cases
* Raise formencode.Invalid if 'between' filter has None value1
* If value2 is None, replace it with today

Fixes #36
Ref level12/rrs-web-repo#708