### PR TITLE
Allow list for render_in attribute of Column

### DIFF
--- a/webgrid/__init__.py
+++ b/webgrid/__init__.py
@@ -9,7 +9,7 @@ import warnings
 
 from blazeutils.containers import HTMLAttributes
 from blazeutils.datastructures import BlankObject, OrderedDict
-from blazeutils.helpers import ensure_tuple
+from blazeutils.helpers import tolist
 from blazeutils.numbers import decimalfmt
 from blazeutils.strings import case_cw2us, randchars
 from blazeutils.spreadsheets import xlsxwriter
@@ -128,7 +128,7 @@ class Column(object):
         self.grid = None
         self.expr = None
         if render_in is not _None:
-            self.render_in = ensure_tuple(render_in)
+            self.render_in = tuple(tolist(render_in))
         if xls_width:
             self.xls_width = xls_width
         if xls_num_format:

--- a/webgrid/tests/test_columns.py
+++ b/webgrid/tests/test_columns.py
@@ -207,6 +207,7 @@ class TestColumn(object):
             YesNoColumn('C4', Person.inactive.label('yesno'), render_in='xlsx')
             DateColumn('Date', Person.due_date, render_in='xls')
             DateColumn('DateTime', Person.createdts, render_in='xls')
+            BoolColumn('C5', Person.inactive, render_in=['xls', 'html'])
         g = TG()
 
         eq_(g.columns[0].render_in, ('html', 'xls', 'xlsx', 'csv'))
@@ -216,6 +217,7 @@ class TestColumn(object):
         eq_(g.columns[4].render_in, ('xlsx',))
         eq_(g.columns[5].render_in, ('xls',))
         eq_(g.columns[6].render_in, ('xls',))
+        eq_(g.columns[7].render_in, ('xls', 'html'))
 
     def test_number_formatting(self):
         class TG(Grid):


### PR DESCRIPTION
* Use tolist followed by tuple to handle tuples, lists, and strings

Fixes #20