### PR TITLE
improve multiselect filter responsiveness for large data sets

### DIFF
--- a/webgrid/renderers.py
+++ b/webgrid/renderers.py
@@ -223,7 +223,50 @@ class HTML(Renderer):
             multiple = 'multiple' if filter.receives_list else ''
             inputs += tags.select(field_name, current_selected,
                                   self.filtering_filter_options(filter), multiple=multiple)
+            if filter.receives_list:
+                inputs += self.filtering_multiselect(
+                    field_name, current_selected,
+                    self.filtering_filter_options_multi(filter, field_name))
         return inputs
+
+    def filtering_multiselect(self, field_name, current_selected, options):
+        return _HTML.div(
+            _HTML.button(
+                _HTML.span(
+                    class_='placeholder'
+                ),
+                _HTML.div(),
+                type='button',
+                class_='ms-choice',
+            ),
+            _HTML.div(
+                _HTML.div(
+                    _HTML.input(
+                        type='text',
+                        autocomplete='off',
+                        autocorrect='off',
+                        autocapitalize='off',
+                        spellcheck='false',
+                    ),
+                    class_='ms-search',
+                ),
+                _HTML.ul(
+                    _HTML.li(
+                        _HTML.label(
+                            _HTML.input(
+                                type='checkbox',
+                                name='selectAll{}'.format(field_name)
+                            ),
+                            '[' + _('Select all') + ']'
+                        )
+                    ),
+                    *options,
+                    _HTML.li(_('No matches found'), class_='ms-no-results'),
+                ),
+                class_='ms-drop bottom'
+            ),
+            class_='ms-parent',
+        )
 
     def filtering_filter_options(self, filter):
         # webhelpers2 doesn't allow options to be lists or tuples anymore. If this is the case,
@@ -234,6 +277,21 @@ class HTML(Renderer):
                 value=option[0]
             ) if isinstance(option, (tuple, list)) else option) for option in filter.options_seq
         ]
+
+    def filtering_filter_options_multi(self, filter, field_name):
+        return (
+            _HTML.li(
+                _HTML.label(
+                    _HTML.input(
+                        type='checkbox',
+                        value=option[0],
+                        checked=(option[0] in (filter.value1 or [])),
+                        name='selectItem{}'.format(field_name)
+                    ),
+                    option[1],
+                )
+            ) for option in filter.options_seq
+        )
 
     def filtering_col_inputs2(self, col):
         filter = col.filter

--- a/webgrid/static/jquery.multiple.select.js
+++ b/webgrid/static/jquery.multiple.select.js
@@ -1,7 +1,7 @@
 /**
  * @author zhixin wen <wenzhixin2010@gmail.com>
  * @version 1.1.0
- * 
+ *
  * http://wenzhixin.net.cn/p/multiple-select/
  */
 
@@ -25,13 +25,9 @@ if (typeof _ === "undefined") {
         this.$el = $el.hide();
         this.options = options;
 
-        this.$parent = $('<div class="ms-parent"></div>');
-        this.$choice = $('<button type="button" class="ms-choice"><span class="placeholder">' +
-            options.placeholder + '</span><div></div></button>');
-        this.$drop = $('<div class="ms-drop ' + options.position + '"></div>');
-        this.$el.after(this.$parent);
-        this.$parent.append(this.$choice);
-        this.$parent.append(this.$drop);
+        this.$parent = this.$el.siblings('.ms-parent');
+        this.$choice = this.$parent.children('.ms-choice');
+        this.$drop = this.$parent.children('.ms-drop');
 
         if (this.$el.prop('disabled')) {
             this.$choice.addClass('disabled');
@@ -64,32 +60,6 @@ if (typeof _ === "undefined") {
         constructor : MultipleSelect,
 
         init: function() {
-            var that = this,
-                html = [];
-            if (this.options.filter) {
-                html.push(
-                    '<div class="ms-search">',
-                        '<input type="text" autocomplete="off" autocorrect="off" autocapitilize="off" spellcheck="false">',
-                    '</div>'
-                );
-            }
-            html.push('<ul>');
-            if (this.options.selectAll && !this.options.single) {
-                html.push(
-                    '<li>',
-                        '<label>',
-                            '<input type="checkbox" ' + this.selectAllName + ' /> ',
-                            '[' + this.options.selectAllText + ']',
-                        '</label>',
-                    '</li>'
-                );
-            }
-            $.each(this.$el.children(), function(i, elm) {
-                html.push(that.optionToHtml(i, elm));
-            });
-            html.push('<li class="ms-no-results">' + _('No matches found', 'webgrid') + '</li>');
-            html.push('</ul>');
-            this.$drop.html(html.join(''));
             this.$drop.find('ul').css('max-height', this.options.maxHeight + 'px');
             this.$drop.find('.multiple').css('width', this.options.multipleWidth + 'px');
 
@@ -105,53 +75,6 @@ if (typeof _ === "undefined") {
             if (this.options.isOpen) {
                 this.open();
             }
-        },
-
-        optionToHtml: function(i, elm, group, groupDisabled) {
-            var that = this,
-                $elm = $(elm),
-                html = [],
-                multiple = this.options.multiple,
-                disabled,
-                type = this.options.single ? 'radio' : 'checkbox';
-
-            if ($elm.is('option')) {
-                var value = $elm.val(),
-                    text = $elm.text(),
-                    selected = $elm.prop('selected'),
-                    style = this.options.styler(value) ? ' style="' + this.options.styler(value) + '"' : '';
-
-                disabled = groupDisabled || $elm.prop('disabled');
-                html.push(
-                    '<li' + (multiple ? ' class="multiple"' : '') + style + '>',
-                        '<label' + (disabled ? ' class="disabled"' : '') + '>',
-                            '<input type="' + type + '" ' + this.selectItemName + ' value="' + value + '"' +
-                                (selected ? ' checked="checked"' : '') +
-                                (disabled ? ' disabled="disabled"' : '') +
-                                (group ? ' data-group="' + group + '"' : '') +
-                                '/> ',
-                            text,
-                        '</label>',
-                    '</li>'
-                );
-            } else if (!group && $elm.is('optgroup')) {
-                var _group = 'group_' + i,
-                    label = $elm.attr('label');
-
-                disabled = $elm.prop('disabled');
-                html.push(
-                    '<li class="group">',
-                        '<label class="optgroup' + (disabled ? ' disabled' : '') + '" data-group="' + _group + '">',
-                            '<input type="checkbox" ' + this.selectGroupName +
-                                (disabled ? ' disabled="disabled"' : '') + ' /> ',
-                            label,
-                        '</label>',
-                    '</li>');
-                $.each($elm.children(), function(i, elm) {
-                    html.push(that.optionToHtml(i, elm, _group, disabled));
-                });
-            }
-            return html.join('');
         },
 
         events: function() {
@@ -218,15 +141,12 @@ if (typeof _ === "undefined") {
             }
             this.options.isOpen = true;
             this.$choice.find('>div').addClass('open');
+            this.$drop.find('input').show();
             this.$drop.show();
             if (this.options.container) {
                 var offset = this.$drop.offset();
                 this.$drop.appendTo($(this.options.container));
                 this.$drop.offset({ top: offset.top, left: offset.left });
-            }
-            if (this.options.filter) {
-                this.$searchInput.val('');
-                this.filter();
             }
             this.options.onOpen();
         },

--- a/webgrid/static/jquery.multiple.select.js
+++ b/webgrid/static/jquery.multiple.select.js
@@ -17,7 +17,7 @@ if (typeof _ === "undefined") {
 
     'use strict';
 
-    function MultipleSelect($el, options) {
+    function WebGridMultipleSelect($el, options) {
         var that = this,
             name = $el.attr('name') || options.name || '',
             elWidth = $el.width();
@@ -56,8 +56,8 @@ if (typeof _ === "undefined") {
         this.selectItemName = 'name="selectItem' + name + '"';
     }
 
-    MultipleSelect.prototype = {
-        constructor : MultipleSelect,
+    WebGridMultipleSelect.prototype = {
+        constructor : WebGridMultipleSelect,
 
         init: function() {
             this.$drop.find('ul').css('max-height', this.options.maxHeight + 'px');
@@ -324,7 +324,7 @@ if (typeof _ === "undefined") {
         }
     };
 
-    $.fn.multipleSelect = function() {
+    $.fn.webgridMultipleSelect = function() {
         var option = arguments[0],
             args = arguments,
 
@@ -340,11 +340,11 @@ if (typeof _ === "undefined") {
         this.each(function() {
             var $this = $(this),
                 data = $this.data('multipleSelect'),
-                options = $.extend({}, $.fn.multipleSelect.defaults,
+                options = $.extend({}, $.fn.webgridMultipleSelect.defaults,
                     $this.data(), typeof option === 'object' && option);
 
             if (!data) {
-                data = new MultipleSelect($this, options);
+                data = new WebGridMultipleSelect($this, options);
                 $this.data('multipleSelect', data);
             }
 
@@ -361,7 +361,7 @@ if (typeof _ === "undefined") {
         return value ? value : this;
     };
 
-    $.fn.multipleSelect.defaults = {
+    $.fn.webgridMultipleSelect.defaults = {
         name: '',
         isOpen: false,
         placeholder: '',

--- a/webgrid/static/webgrid.css
+++ b/webgrid/static/webgrid.css
@@ -272,6 +272,7 @@ table.datagrid td a.delete_link {
 /* multipleselect style overrides */
 div.ms-parent input[type="checkbox"] {
     top: auto;
+    margin-right: 0.25em;
 }
 
 .ms-choice {

--- a/webgrid/static/webgrid.js
+++ b/webgrid/static/webgrid.js
@@ -40,15 +40,10 @@ function datagrid_activate_mselect_ui(jq_select) {
     if ( use_all_opt ) {
         $(all_opt).detach();
     }
-    if (jq_select.siblings('.ms-parent').length > 0) {
+    if (jq_select.data('multipleSelect')) {
         jq_select.hide();
-        jq_select.siblings('.ms-parent').show();
     } else {
         jq_select.multipleSelect({
-            container: 'body',
-            onOpen: function() {
-                $('.ms-drop input').show();
-            },
             minumimCountSelected: 2,
             filter: true
         });
@@ -56,6 +51,7 @@ function datagrid_activate_mselect_ui(jq_select) {
             $(this).css('width', $(this).width() + 60);
         });
     }
+    jq_select.siblings('.ms-parent').show();
     jq_select.attr('multiple', 'multiple');
     if ( use_all_opt ) {
         $(all_opt).prependTo(jq_select);

--- a/webgrid/static/webgrid.js
+++ b/webgrid/static/webgrid.js
@@ -43,7 +43,7 @@ function datagrid_activate_mselect_ui(jq_select) {
     if (jq_select.data('multipleSelect')) {
         jq_select.hide();
     } else {
-        jq_select.multipleSelect({
+        jq_select.webgridMultipleSelect({
             minumimCountSelected: 2,
             filter: true
         });


### PR DESCRIPTION
Performance issues largely centered around the multiselect jQuery plugin. Resolving via a few approaches:
- all multiselect filters are getting the plugin, so just render the HTML in the renderer, instead of doing it all in JS
- modern browsers don't need the container option set to body, dropping that
- resetting the filter's search box on open really slows down the open process for large sets