### PR TITLE
Fix DateFilter and DateTimeFilter logic

### DIFF
--- a/webgrid/tests/test_filters.py
+++ b/webgrid/tests/test_filters.py
@@ -287,11 +287,21 @@ class TestDateFilter(CheckFilterBase):
         with assert_raises(formencode.Invalid):
             filter.set('eq', None)
 
+    def test_eq_default(self):
+        filter = DateFilter(Person.due_date, default_op='eq')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_not_eq(self):
         filter = DateFilter(Person.due_date)
         filter.set('!eq', '12/31/2010')
         self.assert_filter_query(filter, "WHERE persons.due_date != '2010-12-31'")
         eq_(filter.description, 'excluding 12/31/2010')
+
+    def test_noteq_default(self):
+        filter = DateFilter(Person.due_date, default_op='!eq')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_not_eq_none(self):
         filter = DateFilter(Person.due_date)
@@ -306,6 +316,11 @@ class TestDateFilter(CheckFilterBase):
         with assert_raises(formencode.Invalid):
             filter.set('lte', '')
 
+    def test_lte_default(self):
+        filter = DateFilter(Person.due_date, default_op='lte')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_lte_none(self):
         filter = DateFilter(Person.due_date)
         with assert_raises(formencode.Invalid):
@@ -316,6 +331,11 @@ class TestDateFilter(CheckFilterBase):
         filter.set('gte', '12/31/2010')
         self.assert_filter_query(filter, "WHERE persons.due_date >= '2010-12-31'")
         eq_(filter.description, 'beginning 12/31/2010')
+
+    def test_gte_default(self):
+        filter = DateFilter(Person.due_date, default_op='gte')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_gte_none(self):
         figter = DateFilter(Person.due_date)
@@ -331,6 +351,11 @@ class TestDateFilter(CheckFilterBase):
         self.assert_filter_query(filter, "WHERE persons.due_date IS NULL")
         eq_(filter.description, 'date not specified')
 
+    def test_empty_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='empty')
+        filter.set(None, None)
+        eq_(filter.description, 'date not specified')
+
     def test_not_empty(self):
         filter = DateFilter(Person.due_date)
         filter.set('!empty', None)
@@ -338,6 +363,11 @@ class TestDateFilter(CheckFilterBase):
         eq_(filter.description, 'any date')
         filter.set('!empty', '')
         self.assert_filter_query(filter, "WHERE persons.due_date IS NOT NULL")
+        eq_(filter.description, 'any date')
+
+    def test_not_empty_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='!empty')
+        filter.set(None, None)
         eq_(filter.description, 'any date')
 
     def test_between(self):
@@ -388,6 +418,11 @@ class TestDateFilter(CheckFilterBase):
         eq_(filter.error, True)
         eq_(filter.description, 'invalid')
 
+    def test_between_default(self):
+        filter = DateFilter(Person.due_date, default_op='between')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_not_between_missing_date(self):
         filter = DateFilter(Person.due_date)
         filter.set('!between', '12/31/2010', '')
@@ -420,11 +455,21 @@ class TestDateFilter(CheckFilterBase):
         )
         eq_(filter.description, 'excluding 01/31/2010 - 12/31/2010')
 
+    def test_not_between_default(self):
+        filter = DateFilter(Person.due_date, default_op='!between')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_days_ago(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
         filter.set('da', '10')
         self.assert_filter_query(filter, "WHERE persons.due_date = '2011-12-22'")
         eq_(filter.description, '12/22/2011')
+
+    def test_days_ago_default(self):
+        filter = DateFilter(Person.due_date, default_op='da')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_days_ago_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
@@ -440,6 +485,11 @@ class TestDateFilter(CheckFilterBase):
         )
         eq_(filter.description, '12/22/2011 - 01/01/2012')
 
+    def test_less_than_days_ago_default(self):
+        filter = DateFilter(Person.due_date, default_op='ltda')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_less_than_days_ago_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
         with assert_raises(formencode.Invalid):
@@ -450,6 +500,11 @@ class TestDateFilter(CheckFilterBase):
         filter.set('mtda', '10')
         self.assert_filter_query(filter, "WHERE persons.due_date < '2011-12-22'")
         eq_(filter.description, 'before 12/22/2011')
+
+    def test_more_than_days_ago_default(self):
+        filter = DateFilter(Person.due_date, default_op='mtda')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_more_than_days_ago_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
@@ -465,6 +520,11 @@ class TestDateFilter(CheckFilterBase):
         )
         eq_(filter.description, '01/01/2012 - 01/11/2012')
 
+    def test_in_less_than_days_default(self):
+        filter = DateFilter(Person.due_date, default_op='iltd')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_in_less_than_days_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
         with assert_raises(formencode.Invalid):
@@ -475,6 +535,11 @@ class TestDateFilter(CheckFilterBase):
         filter.set('imtd', '10')
         self.assert_filter_query(filter, "WHERE persons.due_date > '2012-01-11'")
         eq_(filter.description, 'after 01/11/2012')
+
+    def test_in_more_than_days_default(self):
+        filter = DateFilter(Person.due_date, default_op='imtd')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_in_more_than_days_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
@@ -487,6 +552,11 @@ class TestDateFilter(CheckFilterBase):
         self.assert_filter_query(filter, "WHERE persons.due_date = '2012-01-11'")
         eq_(filter.description, '01/11/2012')
 
+    def test_in_days_default(self):
+        filter = DateFilter(Person.due_date, default_op='ind')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_in_days_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
         with assert_raises(formencode.Invalid):
@@ -498,10 +568,20 @@ class TestDateFilter(CheckFilterBase):
         self.assert_filter_query(filter, "WHERE persons.due_date = '2012-01-01'")
         eq_(filter.description, '01/01/2012')
 
+    def test_today_default(self):
+        filter = DateFilter(Person.due_date, default_op='today', _now=dt.date(2012, 1, 1))
+        filter.set(None, None)
+        eq_(filter.description, '01/01/2012')
+
     def test_this_week(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 4))
         filter.set('thisweek', None)
         self.assert_filter_query(filter, self.between_week_sql)
+        eq_(filter.description, '01/01/2012 - 01/07/2012')
+
+    def test_this_week_default(self):
+        filter = DateFilter(Person.due_date, default_op='thisweek', _now=dt.date(2012, 1, 4))
+        filter.set(None, None)
         eq_(filter.description, '01/01/2012 - 01/07/2012')
 
     def test_this_week_left_edge(self):
@@ -527,6 +607,11 @@ class TestDateFilter(CheckFilterBase):
         self.assert_filter_query(filter, self.between_sql)
         eq_(filter.description, '01/01/2012 - 01/31/2012')
 
+    def test_this_month_default(self):
+        filter = DateFilter(Person.due_date, default_op='thismonth', _now=dt.date(2012, 1, 4))
+        filter.set(None, None)
+        eq_(filter.description, '01/01/2012 - 01/31/2012')
+
     def test_this_month_left_edge(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 1, 1))
         filter.set('thismonth', None)
@@ -543,6 +628,11 @@ class TestDateFilter(CheckFilterBase):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 2, 4))
         filter.set('lastmonth', None)
         self.assert_filter_query(filter, self.between_sql)
+        eq_(filter.description, '01/01/2012 - 01/31/2012')
+
+    def test_last_month_default(self):
+        filter = DateFilter(Person.due_date, default_op='lastmonth', _now=dt.date(2012, 2, 4))
+        filter.set(None, None)
         eq_(filter.description, '01/01/2012 - 01/31/2012')
 
     def test_last_month_left_edge(self):
@@ -580,6 +670,11 @@ class TestDateFilter(CheckFilterBase):
         filter.set('selmonth', 1, 2012)
         self.assert_filter_query(filter, self.between_sql)
         eq_(filter.description, 'Jan 2012')
+
+    def test_selmonth_default(self):
+        filter = DateFilter(Person.due_date, default_op='selmonth', _now=dt.date(2012, 2, 4))
+        filter.set(None, None)
+        eq_(filter.description, 'All')
 
     def test_selmonth_none(self):
         filter = DateFilter(Person.due_date, _now=dt.date(2012, 2, 4))
@@ -677,6 +772,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "AND '2010-12-31 23:59:59.999999'")
         eq_(filter.value1_set_with, '12/31/2010')
 
+    def test_eq_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='eq')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_eq_none(self):
         filter = DateTimeFilter(Person.createdts)
         with assert_raises(formencode.Invalid):
@@ -696,6 +796,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "WHERE persons.createdts NOT BETWEEN '2010-12-31 00:00:00.000000' AND "
             "'2010-12-31 23:59:59.999999'")
         eq_(filter.value1_set_with, '12/31/2010')
+
+    def test_not_eq_default(self):
+        filter = DateFilter(Person.createdts, default_op='!eq')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_not_eq_none(self):
         filter = DateTimeFilter(Person.createdts)
@@ -718,10 +823,20 @@ class TestDateTimeFilter(CheckFilterBase):
         with assert_raises(formencode.Invalid):
             filter.set('lte', None)
 
+    def test_lte_default(self):
+        filter = DateFilter(Person.createdts, default_op='lte')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_lte_with_time(self):
         filter = DateTimeFilter(Person.createdts)
         filter.set('lte', '12/31/2010 12:00')
         self.assert_filter_query(filter, "WHERE persons.createdts <= '2010-12-31 12:00:00.000000'")
+
+    def test_lte_none(self):
+        filter = DateTimeFilter(Person.createdts)
+        with assert_raises(formencode.Invalid):
+            filter.set('lte', None)
 
     def test_gte(self):
         filter = DateTimeFilter(Person.createdts)
@@ -730,6 +845,16 @@ class TestDateTimeFilter(CheckFilterBase):
         eq_(filter.value1_set_with, '12/31/2010')
         with assert_raises(formencode.Invalid):
             filter.set('gte', '')
+        with assert_raises(formencode.Invalid):
+            filter.set('gte', None)
+
+    def test_gte_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='gte')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
+    def test_gte_none(self):
+        filter = DateTimeFilter(Person.createdts)
         with assert_raises(formencode.Invalid):
             filter.set('gte', None)
 
@@ -745,12 +870,22 @@ class TestDateTimeFilter(CheckFilterBase):
         filter.set('empty', '')
         self.assert_filter_query(filter, "WHERE persons.createdts IS NULL")
 
+    def test_empty_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='empty')
+        filter.set(None, None)
+        eq_(filter.description, 'date not specified')
+
     def test_not_empty(self):
         filter = DateTimeFilter(Person.createdts)
         filter.set('!empty', None)
         self.assert_filter_query(filter, "WHERE persons.createdts IS NOT NULL")
         filter.set('!empty', '')
         self.assert_filter_query(filter, "WHERE persons.createdts IS NOT NULL")
+
+    def test_not_empty_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='!empty')
+        filter.set(None, None)
+        eq_(filter.description, 'any date')
 
     def test_between(self):
         filter = DateTimeFilter(Person.createdts)
@@ -761,6 +896,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "'2010-12-31 23:59:59.999999'")
         eq_(filter.value1_set_with, '01/31/2010 12:00 AM')
         eq_(filter.value2_set_with, '12/31/2010 11:59 PM')
+
+    def test_between_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='between')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_between_none(self):
         filter = DateTimeFilter(Person.createdts)
@@ -811,6 +951,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "WHERE persons.createdts NOT BETWEEN '2010-01-31 00:00:00.000000' AND "
             "'2010-12-31 23:59:59.999999'")
 
+    def test_not_between_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='!between')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_not_between_none(self):
         filter = DateTimeFilter(Person.createdts)
         with assert_raises(formencode.Invalid):
@@ -823,6 +968,11 @@ class TestDateTimeFilter(CheckFilterBase):
             filter,
             "WHERE persons.createdts BETWEEN '2011-12-22 00:00:00.000000' AND "
             "'2011-12-22 23:59:59.999999'")
+
+    def test_days_ago_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='da')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_days_ago_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 1, 1))
@@ -842,6 +992,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "WHERE persons.createdts > '2011-12-22 23:59:59.999999' AND "
             "persons.createdts < '2012-01-01 00:00:00.000000'")
 
+    def test_less_than_days_ago_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='ltda')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_less_than_days_ago_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 1, 1))
         with assert_raises(formencode.Invalid):
@@ -851,6 +1006,11 @@ class TestDateTimeFilter(CheckFilterBase):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 1, 1))
         filter.set('mtda', '10')
         self.assert_filter_query(filter, "WHERE persons.createdts < '2011-12-22 00:00:00.000000'")
+
+    def test_more_than_days_ago_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='mtda')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_more_than_days_ago_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 1, 1))
@@ -865,6 +1025,11 @@ class TestDateTimeFilter(CheckFilterBase):
             "WHERE persons.createdts >= '2012-01-01 12:35:00.000000' AND "
             "persons.createdts < '2012-01-11 00:00:00.000000'")
 
+    def test_in_less_than_days_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='iltd')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
+
     def test_in_less_than_days_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 1, 12, 35))
         with assert_raises(formencode.Invalid):
@@ -874,6 +1039,11 @@ class TestDateTimeFilter(CheckFilterBase):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 1, 12, 35))
         filter.set('imtd', '10')
         self.assert_filter_query(filter, "WHERE persons.createdts > '2012-01-11 23:59:59.999999'")
+
+    def test_in_more_than_days_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='imtd')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_in_more_than_days_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 1, 12, 35))
@@ -887,6 +1057,11 @@ class TestDateTimeFilter(CheckFilterBase):
             filter,
             "WHERE persons.createdts BETWEEN '2012-01-11 00:00:00.000000' AND "
             "'2012-01-11 23:59:59.999999'")
+
+    def test_in_days_default(self):
+        filter = DateTimeFilter(Person.createdts, default_op='ind')
+        filter.set(None, None)
+        eq_(filter.description, 'all')
 
     def test_in_days_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 1, 12, 35))
@@ -906,6 +1081,12 @@ class TestDateTimeFilter(CheckFilterBase):
             "WHERE persons.createdts BETWEEN '2012-01-01 00:00:00.000000' AND "
             "'2012-01-01 23:59:59.999999'")
 
+    def test_today_default(self):
+        filter = DateTimeFilter(
+            Person.createdts, default_op='today', _now=dt.datetime(2012, 1, 1, 12, 35))
+        filter.set(None, None)
+        eq_(filter.description, '01/01/2012')
+
     def test_this_week(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 4, 12, 35))
         filter.set('thisweek', None)
@@ -913,6 +1094,12 @@ class TestDateTimeFilter(CheckFilterBase):
             filter,
             "WHERE persons.createdts BETWEEN '2012-01-01 00:00:00.000000' AND "
             "'2012-01-07 23:59:59.999999'")
+
+    def test_this_week_default(self):
+        filter = DateTimeFilter(
+            Person.createdts, default_op='thisweek', _now=dt.datetime(2012, 1, 4, 12, 35))
+        filter.set(None, None)
+        eq_(filter.description, '01/01/2012 - 01/07/2012')
 
     def test_this_week_left_edge(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.datetime(2012, 1, 1))
@@ -960,6 +1147,12 @@ class TestDateTimeFilter(CheckFilterBase):
         self.assert_filter_query(filter, self.between_sql)
         eq_(filter.description, '01/01/2012 - 01/31/2012')
 
+    def test_this_month_default(self):
+        filter = DateTimeFilter(
+            Person.createdts, default_op='thismonth', _now=dt.date(2012, 1, 4))
+        filter.set(None, None)
+        eq_(filter.description, '01/01/2012 - 01/31/2012')
+
     def test_this_month_left_edge(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 1, 1))
         filter.set('thismonth', None)
@@ -976,6 +1169,12 @@ class TestDateTimeFilter(CheckFilterBase):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 2, 4))
         filter.set('lastmonth', None)
         self.assert_filter_query(filter, self.between_sql)
+        eq_(filter.description, '01/01/2012 - 01/31/2012')
+
+    def test_last_month_default(self):
+        filter = DateTimeFilter(
+            Person.createdts, default_op='lastmonth', _now=dt.date(2012, 2, 4))
+        filter.set(None, None)
         eq_(filter.description, '01/01/2012 - 01/31/2012')
 
     def test_last_month_left_edge(self):
@@ -1015,6 +1214,12 @@ class TestDateTimeFilter(CheckFilterBase):
         filter.set('selmonth', 1, 2012)
         self.assert_filter_query(filter, self.between_sql)
         eq_(filter.description, 'Jan 2012')
+
+    def test_selmonth_default(self):
+        filter = DateTimeFilter(
+            Person.createdts, default_op='selmonth', _now=dt.date(2012, 2, 4))
+        filter.set(None, None)
+        eq_(filter.description, 'All')
 
     def test_selmonth_none(self):
         filter = DateTimeFilter(Person.createdts, _now=dt.date(2012, 2, 4))


### PR DESCRIPTION
- Fix default op bug introduced after prior refactoring
- Raise an error when operator is missing a required value
- Improve test coverage to prevent future breakages

Fixes #91

Makes error handling more explicit, boosts test coverage, and guards against missing values.