### PR TITLE
allow query prep via grid configuration

### DIFF
--- a/webgrid/tests/test_unit.py
+++ b/webgrid/tests/test_unit.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import MultiDict
 from webgrid import Column, BoolColumn, YesNoColumn
 from webgrid.filters import FilterBase, TextFilter, IntFilter
 from webgrid_ta.model.entities import Person, Status, db
-from webgrid_ta.grids import Grid, PeopleGrid
+from webgrid_ta.grids import Grid, PeopleGrid, PeopleGridByConfig
 from .helpers import assert_in_query, assert_not_in_query, query_to_str, inrequest
 from webgrid.renderers import CSV
 
@@ -445,10 +445,11 @@ class TestQueryStringArgs(object):
 
     @inrequest('/foo?dg_perpage=1&dg_onpage=2')
     def test_qs_prefix(self):
-        pg = PeopleGrid(qs_prefix='dg_')
-        pg.apply_qs_args()
-        eq_(pg.on_page, 2)
-        eq_(pg.per_page, 1)
+        for grid_cls in (PeopleGrid, PeopleGridByConfig):
+            pg = grid_cls(qs_prefix='dg_')
+            pg.apply_qs_args()
+            eq_(pg.on_page, 2)
+            eq_(pg.per_page, 1)
 
     @inrequest('/foo?perpage=1&onpage=2')
     def test_qs_paging(self):

--- a/webgrid_ta/grids.py
+++ b/webgrid_ta/grids.py
@@ -72,6 +72,18 @@ class PeopleGrid(Grid):
         return query
 
 
+class PeopleGridByConfig(PeopleGrid):
+    query_outer_joins = (Person.status, )
+    query_default_sort = (Person.id, )
+
+    def query_prep(self, query, has_sort, has_filters):
+        query = query.add_columns(
+            Person.id, Person.lastname, Person.due_date, Person.account_type,
+        ).add_entity(Person)
+
+        return query
+
+
 class DefaultOpGrid(Grid):
     session_on = True
 


### PR DESCRIPTION
- config for joins, outer joins, filtering, and default sort
- attributes are flexible in form, with the exception that relationship attributes must be referenced in tuples due to SQLAlchemy instance magic
fixes #90