### PR TITLE
fix type assumptions in multiselect filter render

### DIFF
--- a/webgrid/renderers.py
+++ b/webgrid/renderers.py
@@ -357,6 +357,7 @@ class HTML(GroupMixin, Renderer):
         )
 
     def filtering_filter_options_multi(self, filter, field_name):
+        # Assume the multiselect filter has been set up with OptionsFilterBase.setup_validator
         selected = filter.value1 or []
         return self._render_jinja(
             '''
@@ -364,7 +365,7 @@ class HTML(GroupMixin, Renderer):
                 <li>
                     <label>
                         <input
-                            {% if value in selected %}checked{% endif %}
+                            {% if transform(value) in selected %}checked{% endif %}
                             type="checkbox"
                             value="{{value}}"
                             name="selectItem{{field_name}}"
@@ -377,6 +378,7 @@ class HTML(GroupMixin, Renderer):
             filter=filter,
             field_name=field_name,
             selected=selected,
+            transform=filter.value_modifier.to_python if filter.value_modifier else lambda x: x,
         )
 
     def filtering_col_inputs2(self, col):

--- a/webgrid/tests/test_rendering.py
+++ b/webgrid/tests/test_rendering.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import csv
 import datetime as dt
+from enum import Enum
 import json
 import io
 
@@ -23,7 +24,7 @@ from webgrid import (
     col_styler,
     row_styler,
 )
-from webgrid.filters import TextFilter
+from webgrid.filters import TextFilter, OptionsEnumFilter
 from webgrid.renderers import (
     CSV,
     HTML,
@@ -515,6 +516,19 @@ class TestHtmlRenderer(object):
         g.key_column_map['firstname'].filter.html_extra = {'data-special-attr': 'foo'}
         filter_html = g.html.filtering_table_row(g.key_column_map['firstname'])
         assert '<tr class="firstname_filter" data-special-attr="foo">' in filter_html, filter_html
+
+    @inrequest('/thepage')
+    def test_multiselect_enum_options(self):
+        class PeopleType(Enum):
+            bob = 'Bob'
+            charlie = 'Charlie'
+
+        g = PeopleGrid()
+        name_filter = OptionsEnumFilter(Person.firstname, enum_type=PeopleType).new_instance()
+        name_filter.set('is', ['bob'])
+        output = g.html.filtering_filter_options_multi(name_filter, 'foo')
+        assert PyQuery(output).find('input[value="bob"]').attr('checked')
+        assert not PyQuery(output).find('input[value="charlie"]').attr('checked')
 
     @inrequest('/thepage')
     def test_confirm_export(self):


### PR DESCRIPTION
- was only rendering checks for string type options
- use the value modifier, if any, to get the true lookup value in the options sequence

fixes #117