### PR TITLE
adjust table controls to use less vertical spacing

### DIFF
--- a/webgrid/renderers.py
+++ b/webgrid/renderers.py
@@ -521,7 +521,7 @@ class HTML(GroupMixin, Renderer):
     def paging_input(self):
         pp_qsk = self.grid.prefix_qs_arg_key('perpage')
         return self._render_jinja(
-            '<input type="text" name="{{name}}" value="{{value}}" />',
+            '<input type="number" min="1" name="{{name}}" value="{{value}}" />',
             name=pp_qsk,
             value=self.grid.per_page
         )

--- a/webgrid/static/webgrid.css
+++ b/webgrid/static/webgrid.css
@@ -31,12 +31,10 @@
 
 .datagrid form.header .links {
     text-align: left;
-    padding-top: 10px;
-    border-top: 1px solid #cccccc;
     /* use long hand form to avoid IE bugs */
     flex-grow: 1;
     flex-shrink: 0;
-    flex-basis: 100%;
+    flex-basis: auto;
 }
 
 .datagrid table.filters {
@@ -81,54 +79,39 @@
     font-style: italic;
 }
 
-.datagrid dl.sorting {
-    margin-right: 15px;
-    margin-bottom: 10px;
-}
-
-.datagrid dl.sorting dd {
-    margin: 4px 0 0 0;
-}
-
-.datagrid dl.sorting select {
-    width: 100%;
-}
-
 .datagrid .paging {
-    padding: 0;
-    margin: 0 15px 5px 0;
-    width: auto;
-    min-width: 250px;
+    flex-basis: auto;
 }
 
-.datagrid .paging dl {
+.datagrid .header dl {
     display: flex;
-    justify-content: space-evenly;
-    flex-wrap: wrap;
+    margin: 0;
+    align-items: center;
 }
 
-.datagrid .paging dl dt,
-.datagrid .paging dl dd {
+.datagrid .header dl dt,
+.datagrid .header dl dd {
     /* use long hand form to avoid IE bugs */
     flex-grow: 1;
     flex-shrink: 0;
-    flex-basis: 33.333%;
-    text-align: center;
-}
-
-.datagrid .paging dl dt {
-    order: 10;
-}
-
-.datagrid .paging dl dd {
-    order: 5;
+    flex-basis: auto;
     margin: 0;
 }
 
-.datagrid .paging input {
-    width: 50px;
+.datagrid .header dl dt {
+    margin-left: 1.25rem;
+    padding-left: 1.25rem;
+    margin-right: .75rem;
+    border-left: solid 1px #bbb;
 }
 
+.datagrid .header dl dt:first-child {
+    border: none;
+}
+
+.datagrid .paging input {
+    width: 8rem;
+}
 
 .datagrid div.footer p {
     float: left;
@@ -309,4 +292,10 @@ div.ms-parent input[type="checkbox"] {
 
 .ms-drop label {
     font-weight: normal;
+}
+
+.datagrid form.header hr.flex-break {
+    flex-basis: 100%;
+    border: none;
+    margin: 0;
 }

--- a/webgrid/static/webgrid.css
+++ b/webgrid/static/webgrid.css
@@ -11,22 +11,17 @@
     padding: 5px;
     background: #efefef;
     margin-bottom: 10px;
+}
+
+.datagrid form.header > div {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
 }
 
-.datagrid form.header > div {
-    /* use long hand form to avoid IE bugs */
-    flex-grow: 0;
-    flex-shrink: 1;
-    flex-basis: auto;
-}
-
-.datagrid form.header select,
-.datagrid form.header input {
-    margin: 0;
-    padding: 0;
+.datagrid form.header > div.bottom {
+    /* wrap-reverse so that the paging controls are above the "Apply" button in mobile */
+    flex-wrap: wrap-reverse;
 }
 
 .datagrid form.header .links {
@@ -35,6 +30,11 @@
     flex-grow: 1;
     flex-shrink: 0;
     flex-basis: auto;
+}
+
+.datagrid form.header .links a {
+    /* push the "reset" link away from the "Apply" button just a bit more */
+    margin-left: .75rem;
 }
 
 .datagrid table.filters {
@@ -77,6 +77,8 @@
 .datagrid tr.add-filter th {
     font-weight: normal;
     font-style: italic;
+    /* keep "Add Filter" from wrapping in mobile */
+    white-space: nowrap;
 }
 
 .datagrid .paging {
@@ -87,6 +89,8 @@
     display: flex;
     margin: 0;
     align-items: center;
+    /* Let paging controls wrap if needed when in mobile */
+    flex-wrap: wrap;
 }
 
 .datagrid .header dl dt,
@@ -107,11 +111,26 @@
 
 .datagrid .header dl dt:first-child {
     border: none;
+    /* In mobile, keeping the mar./pad. looks bad.  Has no visible affect in desktop */
+    margin-left: 0;
+    padding-left: 0;
 }
 
 .datagrid .paging input {
-    width: 8rem;
+    /* Firefox = 5 chars, Chrome = 6 chars */
+    width: 6rem;
+    /* hide up/down arrows to make more room for visible text */
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
 }
+
+.datagrid .paging input[type=number]::-webkit-inner-spin-button,
+.datagrid .paging input[type=number]::-webkit-outer-spin-button {
+    /* Chrome: hide up/down arrows to make more room for visible text */
+    -webkit-appearance: none;
+}
+
 
 .datagrid div.footer p {
     float: left;

--- a/webgrid/templates/grid_header.html
+++ b/webgrid/templates/grid_header.html
@@ -5,27 +5,29 @@
 {%- endif -%}
 
 <form {{ renderer.header_form_attrs(class='header')|wg_attributes }}>
-    <div>
-        {{ renderer.header_filtering()|wg_safe }}
+    <div class="top">
+        <div class="filtering">
+            {{ renderer.header_filtering()|wg_safe }}
+        </div>
+
+        <div class="sorting">
+            {{ renderer.header_sorting()|wg_safe }}
+        </div>
     </div>
 
-    <div>
-        {{ renderer.header_sorting()|wg_safe }}
-    </div>
+    <div class="bottom">
+        <div class="links">
+            <input type="submit" value={{ _('Apply') }} />
+            <!--
+            Webgrid can be configured to load filters from the session.
+            The hidden input is a flag to prevent session loading when the form is submitted.
+            -->
+            <input type="hidden" name="apply" value="" />
+            <a href="{{renderer.reset_url()}}">{{ _('reset') }}</a>
+        </div>
 
-    <hr class="flex-break">
-
-    <div class="links">
-        <input type="submit" value={{ _('Apply') }} />
-        <!--
-        Webgrid can be configured to load filters from the session.
-        The hidden input is a flag to prevent session loading when the form is submitted.
-        -->
-        <input type="hidden" name="apply" value="" />
-        <a href="{{renderer.reset_url()}}">{{ _('reset') }}</a>
-    </div>
-
-    <div class="paging">
-        {{ renderer.header_paging()|wg_safe }}
+        <div class="paging">
+            {{ renderer.header_paging()|wg_safe }}
+        </div>
     </div>
 </form>

--- a/webgrid/templates/grid_header.html
+++ b/webgrid/templates/grid_header.html
@@ -11,8 +11,9 @@
 
     <div>
         {{ renderer.header_sorting()|wg_safe }}
-        {{ renderer.header_paging()|wg_safe }}
     </div>
+
+    <hr class="flex-break">
 
     <div class="links">
         <input type="submit" value={{ _('Apply') }} />
@@ -22,5 +23,9 @@
         -->
         <input type="hidden" name="apply" value="" />
         <a href="{{renderer.reset_url()}}">{{ _('reset') }}</a>
+    </div>
+
+    <div class="paging">
+        {{ renderer.header_paging()|wg_safe }}
     </div>
 </form>

--- a/webgrid/templates/header_paging.html
+++ b/webgrid/templates/header_paging.html
@@ -4,23 +4,21 @@
     {%- endmacro %}
 {%- endif -%}
 
-<div class="paging">
-    <dl>
-        <dt>{{ _('Records') }}</dt>
-        <dd class="record-count">
-            {{ grid.record_count }}
+<dl>
+    <dt>{{ _('Records') }}: </dt>
+    <dd class="record-count">
+        {{ grid.record_count }}
+    </dd>
+
+    {% if grid.pager_on %}
+        <dt>{{ _('Page') }}: </dt>
+        <dd class="page">
+            {{ renderer.paging_select() }}
         </dd>
 
-        {% if grid.pager_on %}
-            <dt>{{ _('Page') }}</dt>
-            <dd class="page">
-                {{ renderer.paging_select() }}
-            </dd>
-
-            <dt>{{ _('Per Page') }}</dt>
-            <dd class="perpage">
-                {{ renderer.paging_input() }}
-            </dd>
-        {% endif %}
-    </dl>
-</div>
+        <dt>{{ _('Per Page') }}: </dt>
+        <dd class="perpage">
+            {{ renderer.paging_input() }}
+        </dd>
+    {% endif %}
+</dl>

--- a/webgrid/templates/header_sorting.html
+++ b/webgrid/templates/header_sorting.html
@@ -6,7 +6,7 @@
 
 {% if grid.sorter_on %}
 <dl class="sorting">
-    <dt>{{ _('Sort By') }}</dt>
+    <dt>{{ _('Sort By') }}:</dt>
     <dd>{{ renderer.sorting_select1() }}</dd>
     <dd>{{ renderer.sorting_select2() }}</dd>
     <dd>{{ renderer.sorting_select3() }}</dd>

--- a/webgrid/templates/header_sorting.html
+++ b/webgrid/templates/header_sorting.html
@@ -5,7 +5,7 @@
 {%- endif -%}
 
 {% if grid.sorter_on %}
-<dl class="sorting">
+<dl>
     <dt>{{ _('Sort By') }}:</dt>
     <dd>{{ renderer.sorting_select1() }}</dd>
     <dd>{{ renderer.sorting_select2() }}</dd>

--- a/webgrid/tests/test_rendering.py
+++ b/webgrid/tests/test_rendering.py
@@ -381,7 +381,7 @@ class TestHtmlRenderer(object):
     def test_paging_html(self):
         g = self.get_grid()
         input_html = g.html.paging_input()
-        assert_tag(input_html, 'input', name='perpage', type='text', value='1')
+        assert_tag(input_html, 'input', name='perpage', type='number', value='1')
 
         img_html = g.html.paging_img_first()
         assert_tag(img_html, 'img', alt='<<', width='16', height='13',


### PR DESCRIPTION
This PR gives us more economical usage of vertical spacing in the grid control area.

## Current

![current](https://user-images.githubusercontent.com/109467/94889989-fe462400-044b-11eb-9b17-bff0c686077f.png)


## Current (mobile)

![current-mobile](https://user-images.githubusercontent.com/109467/94889994-01d9ab00-044c-11eb-8e69-5e8062072ad2.png)

## This PR

![new](https://user-images.githubusercontent.com/109467/94890002-0b631300-044c-11eb-8f3e-67e7e1ec50b2.png)

It doesn't improve things if there are multiple filters, but I felt like making those horizontal wouldn't have been a UX improvement.  

## This PR (mobile)

![new-mobile](https://user-images.githubusercontent.com/109467/94890025-15851180-044c-11eb-832c-26b468937d6d.png)

## Still ToDo

- [x] Test in ~other~ Windows browsers, I tested in latest Firefox and Chrome on Linux.
- [x] The current mobile view is not ideal (if fixing this isn't straight forward, just create a new issue for it.  Not critical IMO)
    - Paging controls don't break to a vertical view and stay horizontal
    - It would be preferable to have the paging controls above the Apply button when in mobile view, but still to the right in desktop view

The mobile view still isn't great, but it's usable on Firefox.  On Chrome's responsible view, the whole layout is of the page [is broken somehow](https://github.com/level12/webgrid/issues/84#issuecomment-702527344).  So I'm punting on any better mobile support for now.