### PR TITLE
handle multiple columns having the same field name

### DIFF
--- a/webgrid/tests/data/basic_table.html
+++ b/webgrid/tests/data/basic_table.html
@@ -8,8 +8,8 @@
             <th class="model"><a href="/?sort1=model">Model</a></th>
             <th><a href="/?sort1=color">Color</a></th>
             <th><a href="/?sort1=active">Active</a></th>
-            <th><a href="/?sort1=active">Active Reverse</a></th>
-            <th><a href="/?sort1=active">Active Yes/No</a></th>
+            <th><a href="/?sort1=active_1">Active Reverse</a></th>
+            <th><a href="/?sort1=active_2">Active Yes/No</a></th>
         </tr>
     </thead>
     <tbody>

--- a/webgrid/tests/test_rendering.py
+++ b/webgrid/tests/test_rendering.py
@@ -214,9 +214,11 @@ class TestHtmlRenderer(object):
     def test_car_html(self):
         key_data = (
             {'id': 1, 'make': 'ford', 'model': 'F150&', 'color': 'pink',
-             'dealer': 'bob', 'dealer_id': '7', 'active': True},
+             'dealer': 'bob', 'dealer_id': '7', 'active': True,
+             'active_1': True, 'active_2': True},
             {'id': 2, 'make': 'chevy', 'model': '1500', 'color': 'blue',
-             'dealer': 'fred', 'dealer_id': '9', 'active': False},
+             'dealer': 'fred', 'dealer_id': '9', 'active': False,
+             'active_1': False, 'active_2': False},
         )
 
         mg = CarGrid()


### PR DESCRIPTION
- when a query expression is given as the column key, track the query key and positional index separately from the grid key string
- grid will handle key string conflicts automatically with a simple suffix
- totals query is adjusted to ensure positional index still applies

fixes #122

Known BC breaks:

_Same SQL column used twice_
Change necessary to have all columns able to be referenced uniquely by key. The difference here is that the second column becomes keyed as `id_1`. This will affect a) view-level or other logic that sets filters, and b) tests for the filters/sorting.
```
    ActionColumn('', Project.id)
    Column('Project ID', Project.id, IntFilter)
```

_"Hack" to render totals differently from general column data_
Totals record used to only have the totaled fields. Now, they have placeholders to allow indexing if possible. In this case, there is now a `__is_total__` attribute present on the totals record, so this would become `hasattr(record, '__is_total__')`.
```
class CustomColumn(NumericColumn):
    # render Yes/No for data, then a numeric count of Yes records in the totals
    def render_html(self, record, hah):
        if not hasattr(record, 'location'):
            if record.field_to_look_at == Decimal('0'):
                return 'No'
            elif record.field_to_look_at == Decimal('1'):
                return 'Yes'
        return super().render_html(record, hah)
```

IMO these are acceptable minor breaks.
