### PR TITLE
reduce clicks needed for common filters

### DIFF
--- a/webgrid/filters.py
+++ b/webgrid/filters.py
@@ -68,6 +68,9 @@ class ops(object):
 
 class FilterBase(object):
     operators = ops.eq, ops.not_eq, ops.empty, ops.not_empty
+    # one operator may be specified as the "primary", i.e. the one to select when filter is added
+    # note, the renderer is responsible for using this operator
+    primary_op = None
     # if needed, specifiy the name of attributes set on the static instance of
     # this class that should get copied over to a new instance by
     # new_instance()
@@ -231,6 +234,7 @@ class _NoValue(object):
 
 class OptionsFilterBase(FilterBase):
     operators = ops.is_, ops.not_is, ops.empty, ops.not_empty
+    primary_op = ops.is_
     input_types = 'select'
     receives_list = True
     options_from = ()
@@ -436,6 +440,7 @@ class OptionsEnumFilter(OptionsFilterBase):
 
 class TextFilter(FilterBase):
     operators = (ops.eq, ops.not_eq, ops.contains, ops.not_contains, ops.empty, ops.not_empty)
+    primary_op = ops.contains
 
     @property
     def comparisons(self):
@@ -1201,6 +1206,7 @@ class YesNoFilter(FilterBase):
         ops.yes,
         ops.no
     )
+    primary_op = ops.yes
 
     def get_search_expr(self):
         def expr(value):

--- a/webgrid/static/webgrid.js
+++ b/webgrid/static/webgrid.js
@@ -114,8 +114,23 @@ function datagrid_activate_filter(filter_key) {
     // Added _filter to address CSS collision with Bootstrap
     // Ref: https://github.com/level12/webgrid/issues/28
     var jq_tr = $('.datagrid .filters tr.' + filter_key+ "_filter");
+
+    if (_datagrid_is_loaded) {
+        // move user-selected filter to the end of the list, so it shows up right where it was selected
+        // note, we don't preserve this ordering through page refresh
+        var detached_row = jq_tr.detach();
+        detached_row.insertBefore('.datagrid .filters tr.add-filter');
+    }
+
     // show the filter's row of controls
     jq_tr.show();
+
+    if (_datagrid_is_loaded) {
+        var primary_filter_op = jq_tr.find('td.operator option[data-render="primary"]').attr('value');
+        jq_tr.find('td.operator select').val(primary_filter_op);
+        // ensure all event handlers (including custom ones) run for op select
+        jq_tr.find('td.operator select').change();
+    }
 
     // make sure the option in the "Add Filter" select box for this
     // filter is disabled
@@ -179,6 +194,13 @@ function datagrid_toggle_filter_inputs(jq_filter_tr) {
                     jq_filter_tr.find('.inputs1 input[name="' + v1name + '"]').removeAttr('name');
                     jq_filter_tr.find('.inputs1 select').attr('name', v1name);
                 }
+                if (_datagrid_is_loaded) {
+                    var mselect = jq_filter_tr.find('.inputs1 select').data('multipleSelect');
+                    if (mselect) {
+                        // note, directly opening did not seem to work, need to call in separate function
+                        setTimeout(function(){mselect.open();}, 10);
+                    }
+                }
             } else {
                 if (_datagrid_is_loaded) {
                     jq_filter_tr.find('.inputs1 input').val('');
@@ -188,6 +210,9 @@ function datagrid_toggle_filter_inputs(jq_filter_tr) {
                 jq_filter_tr.find('.inputs1 .ms-parent').hide();
                 jq_filter_tr.find('.inputs1 input').attr('name',v1name);
                 jq_filter_tr.find('.inputs1 select').removeAttr('name');
+                if (_datagrid_is_loaded) {
+                    jq_filter_tr.find('.inputs1 input').focus();
+                }
             }
         }
         if( field_type == '2inputs' || field_type == 'select+input' ) {

--- a/webgrid/tests/test_rendering.py
+++ b/webgrid/tests/test_rendering.py
@@ -518,6 +518,22 @@ class TestHtmlRenderer(object):
         assert '<tr class="firstname_filter" data-special-attr="foo">' in filter_html, filter_html
 
     @inrequest('/thepage')
+    def test_filter_primary_op_specified(self):
+        g = PeopleGrid()
+        g.key_column_map['firstname'].filter.primary_op = '!eq'
+        filter_html = g.html.filtering_table_row(g.key_column_map['firstname'])
+        assert PyQuery(filter_html).find('option[value="!eq"]').attr('data-render') == 'primary'
+        assert not PyQuery(filter_html).find('option[value="eq"]').attr('data-render')
+
+    @inrequest('/thepage')
+    def test_filter_primary_op_not_specified(self):
+        g = PeopleGrid()
+        g.key_column_map['firstname'].filter.primary_op = None
+        filter_html = g.html.filtering_table_row(g.key_column_map['firstname'])
+        assert PyQuery(filter_html).find('option[value="eq"]').attr('data-render') == 'primary'
+        assert not PyQuery(filter_html).find('option[value="!eq"]').attr('data-render')
+
+    @inrequest('/thepage')
     def test_multiselect_enum_options(self):
         class PeopleType(Enum):
             bob = 'Bob'


### PR DESCRIPTION
- add primary_op to FilterBase and specified for built-in filters. Defaults to first op if none specified.
- auto-select primary op and auto-focus on first filter input when filter is added
- move selected filter to the end of the list (order not preserved through page refresh)

fixes #125