### PR TITLE
use openpyxl for testing xlsx output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ develop_requires = [
     'SQLAlchemyBWC',
     'mock',
     'nose',  # required to import some blazeweb helpers
+    'openpyxl',
     'psycopg2-binary',
     # pinned to version in our package index.
     'pyodbc==4.0.30',


### PR DESCRIPTION
- update tests for xlsx renderer
- add assert_rendered_xlsx_matches with support for multiple header rows
- deprecate assert_rendered_xls_matches
fixes #123