### PR TITLE
clean up args loading

### DIFF
--- a/docs/source/grid/args-loaders.rst
+++ b/docs/source/grid/args-loaders.rst
@@ -1,0 +1,59 @@
+Arguments Loaders
+=================
+
+Grid arguments are run-time configuration for a grid instance. This includes filter
+operator/values, sort terms, search, paging, session key, etc.
+
+Arguments may be provided to the grid directly, or else it pulls them from the assigned
+framework manager. The most common use case will use the manager.
+
+
+Managed arguments
+-----------------
+
+The common use case supported by the defaults has the framework manager providing arguments. In
+this scenario, simply call `apply_qs_args` or `build` to have the grid load these for use in
+queries and rendering::
+
+    class PeopleGrid(Grid):
+        Column('Name', entities.Person.name)
+        Column('Age', entities.Person.age)
+        Column('Location', entities.Person.city)
+
+    grid = PeopleGrid()
+    grid.apply_qs_args()
+
+
+To load the arguments, the grid manager uses "args loaders" - subclasses of ArgsLoader. These
+loaders are run in order of priority, and they are chained: each loader's input is the output of
+the previous loader. The default setup provides request URL arguments to the first loader, and then
+applies session information as needed.
+
+.. autoclass:: webgrid.extensions.ArgsLoader
+    :members:
+
+.. autoclass:: webgrid.extensions.RequestArgsLoader
+    :members:
+
+.. autoclass:: webgrid.extensions.WebSessionArgsLoader
+    :members:
+
+
+Supplying arguments directly
+----------------------------
+
+Arguments may be provided directly to `apply_qs_args` or `build` as a MultiDict. If arguments
+are supplied in this fashion, other sources are ignored.
+
+    from werkzeug.datastructures import MultiDict
+
+    class PeopleGrid(Grid):
+        Column('Name', entities.Person.name)
+        Column('Age', entities.Person.age)
+        Column('Location', entities.Person.city)
+
+    grid = PeopleGrid()
+    grid.apply_qs_args(grid_args=MultiDict([
+        ('op(name)', 'contains'),
+        ('v1(name)', 'bill'),
+    ]))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ With a grid configured from one or more entities, WebGrid provides these feature
    getting-started
    grid/grid
    grid/managers
+   grid/args-loaders
    columns/index
    filters/index
    renderers/index

--- a/webgrid/__init__.py
+++ b/webgrid/__init__.py
@@ -995,13 +995,13 @@ class BaseGrid(six.with_metaclass(_DeclarativeMeta, object)):
         """
         pass
 
-    def build(self):
+    def build(self, grid_args=None):
         """Apply query args, run `before_query_hook`, and execute a record count query.
 
         Calling `build` is preferred to simply calling `apply_qs_args` in a view. Otherwise,
         AttributeErrors can be hidden when the grid is used in Jinja templates.
         """
-        self.apply_qs_args()
+        self.apply_qs_args(grid_args=grid_args)
         self.before_query_hook()
         # this will force the query to execute.  We used to wait to evaluate this but it ended
         # up causing AttributeErrors to be hidden when the grid was used in Jinja.
@@ -1578,13 +1578,13 @@ class BaseGrid(six.with_metaclass(_DeclarativeMeta, object)):
             'Paging is enabled, but query does not have ORDER BY clause required for MSSQL'
         )
 
-    def apply_qs_args(self, add_user_warnings=True):
+    def apply_qs_args(self, add_user_warnings=True, grid_args=None):
         """Process args from manager for filter/page/sort/export.
 
         Args:
             add_user_warnings (bool, optional): Add flash messages for warnings. Defaults to True.
         """
-        args = self.manager.get_args(self)
+        args = grid_args if grid_args is not None else self.manager.get_args(self)
 
         if self.session_on:
             self.session_key = args.get('session_key') or self.session_key

--- a/webgrid/blazeweb.py
+++ b/webgrid/blazeweb.py
@@ -1,40 +1,27 @@
 from __future__ import absolute_import
 
-import io
-import warnings
-from os import path
-
 from blazeweb.content import getcontent
 from blazeweb.globals import ag, rg, user
 from blazeweb.routing import abs_static_url
 from blazeweb.templating.jinja import content_filter
 from blazeweb.utils import abort
 from blazeweb.wrappers import StreamResponse
-import jinja2 as jinja
 from jinja2.exceptions import TemplateNotFound
 from sqlalchemybwc import db as sabwc_db
 from webgrid import BaseGrid
-from webgrid.extensions import gettext
+from webgrid.extensions import FrameworkManager, gettext
 from webgrid.renderers import render_html_attributes
 
 
-class WebGrid(object):
-    jinja_loader = jinja.PackageLoader('webgrid', 'templates')
-
+class WebGrid(FrameworkManager):
     def __init__(self, db=None, component='webgrid'):
-        self.init_db(db or sabwc_db)
+        super().__init__(db=db or sabwc_db)
         self.component = component
+
+    def init(self):
         ag.tplengine.env.filters['wg_safe'] = content_filter
         ag.tplengine.env.filters['wg_attributes'] = render_html_attributes
         ag.tplengine.env.filters['wg_gettext'] = gettext
-        self.jinja_environment = jinja.Environment(
-            loader=self.jinja_loader,
-            finalize=lambda x: x if x is not None else '',
-            autoescape=True
-        )
-
-    def init_db(self, db):
-        self.db = db
 
     def sa_query(self, *args, **kwargs):
         return self.db.sess.query(*args, **kwargs)
@@ -54,9 +41,6 @@ class WebGrid(object):
     def request(self):
         return rg.request
 
-    def static_path(self):
-        return path.join(path.dirname(__file__), 'static')
-
     def static_url(self, url_tail):
         return abs_static_url('component/webgrid/{0}'.format(url_tail))
 
@@ -65,16 +49,6 @@ class WebGrid(object):
         rp.headers['Content-Type'] = mime_type
         rp.headers['Content-Disposition'] = 'attachment; filename={}'.format(file_name)
         abort(rp)
-
-    def xls_as_response(self, wb, file_name):
-        warnings.warn(
-            'xls_as_response is deprecated. Use file_as_response instead',
-            DeprecationWarning
-        )
-        data = io.BytesIO()
-        wb.save(data)
-        data.seek(0)
-        self.file_as_response(data, file_name, 'application/vnd.ms-excel')
 
     def render_template(self, endpoint, **kwargs):
         try:

--- a/webgrid/extensions.py
+++ b/webgrid/extensions.py
@@ -1,3 +1,10 @@
+import json
+from pathlib import Path
+import re
+
+import jinja2 as jinja
+from werkzeug.datastructures import MultiDict
+
 MORPHI_PACKAGE_NAME = 'webgrid'
 
 # begin morphi boilerplate
@@ -37,3 +44,328 @@ else:
 
     lazy_gettext = gettext
     lazy_ngettext = ngettext
+
+
+class ArgsLoader:
+    """ Base args loader class.
+
+    When a grid calls for its args, it requests them from the manager. The manager will have one
+    or more args loaders to be run in order. The first loader is given args from the request,
+    then ensuing loaders have the opportunity to modify or perform other operations as needed.
+    """
+    def __init__(self, manager):
+        self.manager = manager
+
+    def get_args(self, grid, request_args):
+        raise Exception('subclass must override get_args')
+
+
+class RequestArgsLoader(ArgsLoader):
+    """ Simple args loader for web request.
+
+    Args are usually passed through directly from the request. If the grid has a query string
+    prefix, the relevant args will be namespaced - sanitize them here and return the subset
+    needed for the given grid.
+
+    In the reset case, ignore most args, and return only the reset flag and session key (if any).
+    """
+    def sanitize_arg_name(self, arg_name, qs_prefix):
+        if qs_prefix and arg_name.startswith(qs_prefix):
+            return arg_name[len(qs_prefix):]
+        return arg_name
+
+    def get_args(self, grid, request_args):
+        # Start with request args, filtered by query string prefix if there is one
+        incoming_args = []
+        if grid.qs_prefix:
+            for key, values in MultiDict(request_args).lists():
+                # Only include args that start with the grid's prefix
+                if not key.startswith(grid.qs_prefix):
+                    continue
+                key = self.sanitize_arg_name(key, grid.qs_prefix)
+                for single_val in values:
+                    incoming_args.append((key, single_val))
+        else:
+            incoming_args = request_args
+
+        if 'dgreset' in request_args:
+            if 'session_key' in request_args:
+                return MultiDict(dict(dgreset=1, session_key=request_args['session_key']))
+            return MultiDict(dict(dgreset=1))
+
+        return MultiDict(incoming_args)
+
+
+class WebSessionArgsLoader(ArgsLoader):
+    """ Session manager for grid args.
+
+    Args are assumed to have been sanitized from the request already. But, args may be combined
+    from the request and the session store for a number of cases.
+
+    - If session_override or no filter ops, load args from session store
+    - Having filter ops present will reset session store unless session_override is present
+    - Page/sort args will always take precedence over stored args, but not reset the store
+    - Export argument is handled outside of the session store
+
+    In the reset case, ignore most args, and return only the reset flag and session key (if any).
+    And clear the session store for the given grid.
+    """
+    def args_have_op(self, args):
+        """Check args for containing any filter operators.
+
+        Args:
+            args (MultiDict): Request args.
+
+        Returns:
+            bool: True if at least one op is present.
+        """
+        regex = re.compile(r'(op\(.*\))')
+        return any(regex.match(a) for a in args.keys())
+
+    def args_have_page(self, args):
+        """Check args for containing any page args.
+
+        Args:
+            args (MultiDict): Request args.
+
+        Returns:
+            bool: True if at least one page arg is present.
+        """
+        regex = re.compile('(onpage|perpage)')
+        return any(regex.match(a) for a in args.keys())
+
+    def args_have_sort(self, args):
+        """Check args for containing any sort keys.
+
+        Args:
+            args (MultiDict): Request args.
+
+        Returns:
+            bool: True if at least one sort key is present.
+        """
+        regex = re.compile('(sort[1-3])')
+        return any(regex.match(a) for a in args.keys())
+
+    def remove_grid_session(self, session_key):
+        # Remove a grid session from the cookie entirely
+        if 'dgsessions' not in self.manager.web_session():
+            return
+        if session_key not in self.manager.web_session()['dgsessions']:
+            return
+
+        self.manager.web_session()['dgsessions'].pop(session_key)
+        self.manager.persist_web_session()
+
+    def apply_session_overrides(self, session_args, request_args):
+        """ Update session args as needed from the incoming request.
+
+        If session override case, wholesale update from the incoming request. This
+        is useful if a single filter needs to be changed via the URL, but we don't
+        want to dump the rest of the stored filters from the session.
+
+        Otherwise, apply only page/sort if available in the request.
+
+        Export directive is passed through from the request, so a session store never
+        triggers an export by itself.
+
+        Args:
+            session_args (MultiDict): Args loaded from the session store.
+            request_args (MultiDict): Args that came into this args loader.
+
+        Returns:
+            MultiDict: Args to be used in grid operations.
+        """
+        is_override = 'session_override' in request_args
+
+        if is_override:
+            session_args.update(request_args)
+        else:
+            # Some types of args always get passed through from request_args.
+            # Override paging if it exists in the query
+            if self.args_have_page(request_args):
+                session_args['onpage'] = request_args.get('onpage')
+                session_args['perpage'] = request_args.get('perpage')
+            # Override sorting if it exists in the query
+            if self.args_have_sort(request_args):
+                session_args['sort1'] = request_args.get('sort1')
+                session_args['sort2'] = request_args.get('sort2')
+                session_args['sort3'] = request_args.get('sort3')
+
+        if 'export_to' in request_args:
+            # Export directive gets left out of the session storage, since a request may
+            # have session key and export, and filter/sort must be loaded.
+            session_args['export_to'] = request_args['export_to']
+
+        return session_args
+
+    def get_session_store(self, grid, args):
+        """Load args from session by session_key, and return as MultiDict.
+
+        Args:
+            grid (BaseGrid): Grid used to get default grid key (based on grid class name).
+            args (MultiDict): Request args used for session key.
+
+        Returns:
+            MultiDict: Args to be used in grid operations.
+        """
+        # check args for a session key. If the key is present,
+        #   look it up in the session and use the saved args
+        #   (if they have been saved under that key). If not,
+        #   look up the class name for a default arg store.
+        web_session = self.manager.web_session()
+        if 'dgsessions' not in web_session:
+            return args
+        dgsessions = web_session['dgsessions']
+
+        # session is stored as a JSON-serialized list of tuples, which we can turn into MultiDict
+        session_key = grid.default_session_key
+        grid_session_key = args.get('session_key', None)
+        if grid_session_key and dgsessions.get(grid_session_key):
+            session_key = grid_session_key
+        stored_args_json = dgsessions.get(session_key, '[]')
+        if isinstance(stored_args_json, MultiDict):
+            stored_args_json = json.dumps(list(stored_args_json.items(multi=True)))
+        elif isinstance(stored_args_json, dict):
+            stored_args_json = json.dumps(list(stored_args_json.items()))
+        return MultiDict(json.loads(stored_args_json))
+
+    def save_session_store(self, grid, args):
+        """Save the args in the session under the session key and as defaults for this grid.
+
+        Note, export and reset args are ignored for storage.
+
+        Args:
+            args (MultiDict): Request args to be loaded in next session store retrieval.
+        """
+        # save the args in the session under the session key
+        #   and also as the default args for this grid
+        web_session = self.manager.web_session()
+        if 'dgsessions' not in web_session:
+            web_session['dgsessions'] = dict()
+        dgsessions = web_session['dgsessions']
+        grid_session_key = args.get('session_key') or grid.session_key
+        # work with a copy here
+        args = MultiDict(args)
+        # remove keys that should not be stored
+        exclude_keys = (
+            '__foreign_session_loaded__',
+            'apply',
+            'dgreset',
+            'export_to',
+            'session_override',
+        )
+        for key in exclude_keys:
+            args.pop(key, None)
+        args['datagrid'] = grid.default_session_key
+        # serialize the args so we can enforce the correct MultiDict type on the other side
+        args_json = json.dumps(list(args.items(multi=True)))
+        # save in store under grid default and session key
+        dgsessions[grid_session_key] = args_json
+        dgsessions[grid.default_session_key] = args_json
+
+        # some frameworks/sessions need these changes manually persisted
+        self.manager.persist_web_session()
+
+    def get_args(self, grid, request_args):
+        """ Retrieve args from session and override as appropriate.
+
+        Submitting the header form flushes all args to the URL, so no need to load them
+        from session.
+
+        If that is not the path, then we either have filtering args on the URL, or not. Default
+        behavior is currently to consider filtering args to be comprehensive and authoritative,
+        UNLESS a session_override arg is present.
+
+        The special session_override arg causes the store to overlay request args against an
+        existing session, and return the combination.
+
+        Args:
+            grid (BaseGrid): Grid used to get default grid key (based on grid class name).
+            request_args (MultiDict): Incoming args, assumed to be sanitized already.
+
+        Returns:
+            MultiDict: Args to be used in grid operations.
+        """
+        if not grid.session_on:
+            # Shouldn't be a normal case anymore. But if the grid has session store disabled,
+            # honor that and just return the args that came in.
+            return request_args
+
+        if 'dgreset' in request_args:
+            # Request has a reset. Do nothing else.
+            if grid.session_on:
+                self.remove_grid_session(request_args.get('session_key') or grid.session_key)
+                self.remove_grid_session(grid.default_session_key)
+            return MultiDict(dict(dgreset=1, session_key=request_args.get('session_key')))
+
+        # From here on, work with a copy so as not to mutate the incoming args
+        request_args = request_args.copy()
+
+        is_override = 'session_override' in request_args
+        is_apply = 'apply' in request_args
+        if (not self.args_have_op(request_args) and not is_apply) or is_override:
+            # We are in a session-loading case.
+            session_args = self.apply_session_overrides(
+                self.get_session_store(grid, request_args), request_args
+            )
+
+            # Flag a foreign session if loading from another grid's session.
+            session_args['__foreign_session_loaded__'] = (
+                session_args.get('datagrid', grid.default_session_key) != grid.default_session_key
+            )
+
+            # No further need to treat args lists separately.
+            request_args = session_args
+
+        self.save_session_store(grid, request_args)
+        return request_args
+
+
+class FrameworkManager:
+    """Grid manager base class for connecting grids to webapps.
+
+    Provides common framework-related properties and methods.
+
+    Class Attributes:
+        jinja_loader (jinja.Loader): Template loader to use for HTML rendering.
+
+        args_loaders (ArgsLoader[]): Iterable of classes to use for loading grid args, in order
+        of priority
+
+    """
+    jinja_loader = jinja.PackageLoader('webgrid', 'templates')
+    args_loaders = (
+        RequestArgsLoader,
+        WebSessionArgsLoader,
+    )
+
+    def __init__(self, db=None):
+        self.init_db(db)
+        self.init_jinja()
+
+        if callable(getattr(self, 'init', False)):
+            self.init()
+
+    def init_db(self, db):
+        """Set the db connector."""
+        self.db = db
+
+    def init_jinja(self):
+        """Configure grid-specific jinja environment."""
+        self.jinja_environment = jinja.Environment(
+            loader=self.jinja_loader,
+            finalize=lambda x: x if x is not None else '',
+            autoescape=True
+        )
+
+    def static_path(self):
+        """Path where static files are located on the filesystem."""
+        return str(Path(__file__).resolve().parent / 'static')
+
+    def get_args(self, grid):
+        """Run request args through manager's args loaders, and return the result."""
+        args = self.request_args()
+        for loader in self.args_loaders:
+            args = loader(self).get_args(grid, args)
+
+        return args

--- a/webgrid/extensions.py
+++ b/webgrid/extensions.py
@@ -58,6 +58,7 @@ class ArgsLoader:
         self.manager = manager
 
     def get_args(self, grid, request_args):
+        # Override this method for loader-specific processing of request_args
         raise Exception('subclass must override get_args')
 
 

--- a/webgrid/flask.py
+++ b/webgrid/flask.py
@@ -25,6 +25,12 @@ class WebGrid(FrameworkManager):
     Class Attributes:
         jinja_loader (jinja.Loader): Template loader to use for HTML rendering.
 
+        args_loaders (ArgsLoader[]): Iterable of classes to use for loading grid args, in order
+        of priority
+
+        session_max_hours (int): Hours to hold a given grid session in storage. Set to None to
+        disable. Default 12.
+
     """
     def init_db(self, db):
         """Set the db connector."""

--- a/webgrid/tests/test_unit.py
+++ b/webgrid/tests/test_unit.py
@@ -707,6 +707,16 @@ class TestQueryStringArgs(object):
         pg.apply_qs_args()
         assert pg.column('firstname').filter.op == 'eq'
 
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_grid_args_ignores_url(self):
+        pg = PeopleGrid()
+        pg.apply_qs_args(grid_args=MultiDict({
+            'op(firstname)': 'contains',
+            'v1(firstname)': 'bill',
+        }))
+        assert pg.column('firstname').filter.op == 'contains'
+        assert pg.column('firstname').filter.value1 == 'bill'
+
     @inrequest('/foo?op(firstname)=&v1(firstname)=foo&op(status)=&v1(status)=1')
     def test_qs_blank_operator(self):
         pg = PeopleGrid()

--- a/webgrid/tests/test_unit.py
+++ b/webgrid/tests/test_unit.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import re
-from datetime import datetime
 from decimal import Decimal
 from os import path
 
@@ -12,6 +11,7 @@ import sqlalchemy.sql as sasql
 from werkzeug.datastructures import MultiDict
 
 from webgrid import Column, BoolColumn, YesNoColumn
+from webgrid.extensions import RequestArgsLoader, WebSessionArgsLoader
 from webgrid.filters import FilterBase, TextFilter, IntFilter, AggregateIntFilter
 from webgrid_ta.model.entities import Person, Status, Stopwatch, db
 from webgrid_ta.grids import Grid, PeopleGrid, PeopleGridByConfig
@@ -694,18 +694,6 @@ class TestQueryStringArgs(object):
         assert pg.column('firstname').filter.op is None
 
     @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
-    def test_qs_default_session(self):
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        flask.request.args = MultiDict()
-        pg2 = PeopleGrid()
-        pg2.apply_qs_args()
-        assert pg2.column('firstname').filter.op == 'eq'
-        assert '_PeopleGrid' in flask.session['dgsessions']
-        assert pg.session_key in flask.session['dgsessions']
-        assert pg2.session_key in flask.session['dgsessions']
-
-    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
     def test_qs_keyed_session(self):
         pg = PeopleGrid()
         pg.apply_qs_args()
@@ -717,96 +705,6 @@ class TestQueryStringArgs(object):
         pg = PeopleGrid()
         pg.apply_qs_args()
         assert pg.column('firstname').filter.op == 'eq'
-
-    @inrequest('/foo')
-    def test_session_load_from_none(self):
-        # test backwards compatibility for multidict load
-        flask.session['dgsessions'] = {}
-        pg = PeopleGrid()
-        args = pg.get_session_store(MultiDict())
-        assert args == MultiDict([])
-
-    @inrequest('/foo')
-    def test_session_load_from_multidict(self):
-        # test backwards compatibility for multidict load
-        flask.session['dgsessions'] = {
-            '_PeopleGrid': MultiDict([('a', 'b'), ('a', 'c')])
-        }
-        pg = PeopleGrid()
-        args = pg.get_session_store(MultiDict())
-        assert args == MultiDict([('a', 'b'), ('a', 'c')])
-
-    @inrequest('/foo')
-    def test_session_load_from_dict(self):
-        # test backwards compatibility for dict load
-        flask.session['dgsessions'] = {
-            '_PeopleGrid': {'a': 'b', 'c': 'd'}
-        }
-        pg = PeopleGrid()
-        args = pg.get_session_store(MultiDict())
-        assert args == MultiDict([('a', 'b'), ('c', 'd')])
-
-    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
-    def test_qs_keyed_session_with_export(self):
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        flask.request.args['op(firstname)'] = '!eq'
-        pg2 = PeopleGrid()
-        pg2.apply_qs_args()
-        assert pg2.column('firstname').filter.op == '!eq'
-        flask.request.args = MultiDict([
-            ('session_key', pg.session_key),
-            ('export_to', 'xls'),
-        ])
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        assert pg.column('firstname').filter.op == 'eq'
-
-    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
-    def test_qs_keyed_session_with_override(self):
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        flask.request.args = MultiDict([
-            ('session_key', pg.session_key),
-            ('session_override', 1),
-            ('op(createdts)', '!eq'),
-            ('v1(createdts)', '2017-05-06'),
-        ])
-        pg2 = PeopleGrid()
-        pg2.apply_qs_args()
-        assert pg2.column('firstname').filter.op == 'eq'
-        assert pg2.column('firstname').filter.value1 == 'bob'
-        assert pg2.column('createdts').filter.op == '!eq'
-        assert pg2.column('createdts').filter.value1 == datetime(2017, 5, 6)
-
-    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
-    def test_qs_keyed_session_without_override(self):
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        flask.request.args = MultiDict([
-            ('session_key', pg.session_key),
-            ('op(createdts)', '!eq'),
-            ('v1(createdts)', '2017-05-06'),
-        ])
-        pg2 = PeopleGrid()
-        pg2.apply_qs_args()
-        assert not pg2.column('firstname').filter.op
-        assert not pg2.column('firstname').filter.value1
-        assert pg2.column('createdts').filter.op == '!eq'
-        assert pg2.column('createdts').filter.value1 == datetime(2017, 5, 6)
-
-    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
-    def test_qs_apply_prevents_session_load(self):
-        pg = PeopleGrid()
-        pg.apply_qs_args()
-        flask.request.args = MultiDict([
-            ('session_key', pg.session_key),
-            ('apply', None),
-        ])
-        pg2 = PeopleGrid()
-        pg2.apply_qs_args()
-        assert not pg2.column('firstname').filter.op
-        assert not pg2.column('firstname').filter.value1
 
     @inrequest('/foo?op(firstname)=&v1(firstname)=foo&op(status)=&v1(status)=1')
     def test_qs_blank_operator(self):
@@ -889,3 +787,236 @@ class TestQueryStringArgs(object):
         g.enable_search = True
         g.apply_qs_args()
         assert g.search_value is None
+
+
+class TestRequestArgsLoader:
+    def test_passthru(self):
+        source_args = MultiDict([('foo', 'bar'), ('baz', 'bin')])
+        source_args_copy = source_args.copy()
+        grid = PeopleGrid()
+        loader = RequestArgsLoader(grid.manager)
+        result = loader.get_args(grid, source_args)
+        assert result == source_args == source_args_copy
+
+    def test_qs_prefix_filter(self):
+        source_args = MultiDict([('foo', 'bar'), ('baz', 'bin'), ('boo', 'hoo'),
+                                 ('baz', 'bid')])
+        source_args_copy = source_args.copy()
+        grid = PeopleGrid(qs_prefix='b')
+        loader = RequestArgsLoader(grid.manager)
+        result = loader.get_args(grid, source_args)
+        assert source_args == source_args_copy
+        assert result == MultiDict([('az', 'bin'), ('az', 'bid'), ('oo', 'hoo')])
+
+    def test_reset(self):
+        source_args = MultiDict([('foo', 'bar'), ('baz', 'bin'), ('dgreset', '1')])
+        grid = PeopleGrid()
+        loader = RequestArgsLoader(grid.manager)
+        result = loader.get_args(grid, source_args)
+        assert result == MultiDict([('dgreset', 1)])
+
+    def test_reset_with_session_key(self):
+        source_args = MultiDict([('foo', 'bar'), ('baz', 'bin'), ('dgreset', '1'),
+                                 ('session_key', '123')])
+        grid = PeopleGrid()
+        loader = RequestArgsLoader(grid.manager)
+        result = loader.get_args(grid, source_args)
+        assert result == MultiDict([('dgreset', 1), ('session_key', '123')])
+
+
+class TestWebSessionArgsLoader:
+    @inrequest('/foo')
+    def test_no_session_present(self):
+        source_args = MultiDict([('foo', 'bar'), ('baz', 'bin')])
+        source_args_copy = source_args.copy()
+        grid = PeopleGrid()
+        loader = WebSessionArgsLoader(grid.manager)
+        result = loader.get_args(grid, source_args)
+        assert source_args == source_args_copy
+        assert result == MultiDict([
+            ('foo', 'bar'),
+            ('baz', 'bin'),
+            ('__foreign_session_loaded__', False),
+        ])
+
+    @inrequest('/foo?dgreset=1&op(firstname)=eq&v1(firstname)=bob')
+    def test_reset_result(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        args = loader.get_args(pg, flask.request.args)
+        assert args == MultiDict([('dgreset', 1), ('session_key', None)])
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_reset_removes_session(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('dgreset', '1'),
+        ])
+        pg = PeopleGrid()
+        loader.get_args(pg, flask.request.args)
+        assert '_PeopleGrid' not in flask.session['dgsessions']
+        assert pg.session_key not in flask.session['dgsessions']
+
+    @inrequest('/foo')
+    def test_session_load_from_none(self):
+        # test backwards compatibility for multidict load
+        flask.session['dgsessions'] = {}
+        grid = PeopleGrid()
+        loader = WebSessionArgsLoader(grid.manager)
+        args = loader.get_session_store(grid, MultiDict())
+        assert args == MultiDict([])
+
+    @inrequest('/foo')
+    def test_session_load_from_multidict(self):
+        # test backwards compatibility for multidict load
+        flask.session['dgsessions'] = {
+            '_PeopleGrid': MultiDict([('a', 'b'), ('a', 'c')])
+        }
+        grid = PeopleGrid()
+        loader = WebSessionArgsLoader(grid.manager)
+        args = loader.get_session_store(grid, MultiDict())
+        assert args == MultiDict([('a', 'b'), ('a', 'c')])
+
+    @inrequest('/foo')
+    def test_session_load_from_dict(self):
+        # test backwards compatibility for dict load
+        flask.session['dgsessions'] = {
+            '_PeopleGrid': {'a': 'b', 'c': 'd'}
+        }
+        grid = PeopleGrid()
+        loader = WebSessionArgsLoader(grid.manager)
+        args = loader.get_session_store(grid, MultiDict())
+        assert args == MultiDict([('a', 'b'), ('c', 'd')])
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_default_session(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        pg2 = PeopleGrid()
+        loader = WebSessionArgsLoader(pg2.manager)
+        args = loader.get_args(pg2, MultiDict())
+        assert args['op(firstname)'] == 'eq'
+        assert '_PeopleGrid' in flask.session['dgsessions']
+        assert pg.session_key in flask.session['dgsessions']
+        assert pg2.session_key in flask.session['dgsessions']
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_keyed_session(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args['op(firstname)'] = '!eq'
+        pg2 = PeopleGrid()
+        args = loader.get_args(pg2, flask.request.args)
+        assert args['op(firstname)'] == '!eq'
+        flask.request.args = MultiDict([('session_key', pg.session_key)])
+        pg = PeopleGrid()
+        args = loader.get_args(pg, flask.request.args)
+        assert args['op(firstname)'] == 'eq'
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100&sort1=foo')
+    def test_page_args_always_applied(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('perpage', '15'),
+            ('onpage', '100'),
+        ])
+        pg = PeopleGrid()
+        args = loader.get_args(pg, flask.request.args)
+        assert args['op(firstname)'] == 'eq'
+        assert args['perpage'] == '15'
+        assert args['onpage'] == '100'
+        assert args['sort1'] == 'foo'
+        assert '["perpage", "15"]' in flask.session['dgsessions'][pg.session_key]
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100&sort1=foo')
+    def test_sort_args_always_applied(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('sort1', 'bar'),
+        ])
+        pg = PeopleGrid()
+        args = loader.get_args(pg, flask.request.args)
+        assert args['op(firstname)'] == 'eq'
+        assert args['perpage'] == '1'
+        assert args['sort1'] == 'bar'
+        assert '["sort1", "bar"]' in flask.session['dgsessions'][pg.session_key]
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_keyed_session_with_export(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args['op(firstname)'] = '!eq'
+        pg2 = PeopleGrid()
+        args = loader.get_args(pg2, flask.request.args)
+        assert args['op(firstname)'] == '!eq'
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('export_to', 'xls'),
+        ])
+        pg = PeopleGrid()
+        args = loader.get_args(pg, flask.request.args)
+        assert args['op(firstname)'] == 'eq'
+        assert args['export_to'] == 'xls'
+        assert 'export_to' not in flask.session['dgsessions'][pg.session_key]
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_keyed_session_with_override(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('session_override', 1),
+            ('op(createdts)', '!eq'),
+            ('v1(createdts)', '2017-05-06'),
+        ])
+        pg2 = PeopleGrid()
+        args = loader.get_args(pg2, flask.request.args)
+        assert args['op(firstname)'] == 'eq'
+        assert args['v1(firstname)'] == 'bob'
+        assert args['op(createdts)'] == '!eq'
+        assert args['v1(createdts)'] == '2017-05-06'
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_keyed_session_without_override(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('op(createdts)', '!eq'),
+            ('v1(createdts)', '2017-05-06'),
+        ])
+        pg2 = PeopleGrid()
+        args = loader.get_args(pg2, flask.request.args)
+        assert 'op(firstname)' not in args
+        assert 'v1(firstname)' not in args
+        assert args['op(createdts)'] == '!eq'
+        assert args['v1(createdts)'] == '2017-05-06'
+
+    @inrequest('/foo?op(firstname)=eq&v1(firstname)=bob&perpage=1&onpage=100')
+    def test_apply_prevents_session_load(self):
+        pg = PeopleGrid()
+        loader = WebSessionArgsLoader(pg.manager)
+        loader.get_args(pg, flask.request.args)
+        flask.request.args = MultiDict([
+            ('session_key', pg.session_key),
+            ('apply', None),
+        ])
+        pg2 = PeopleGrid()
+        args = loader.get_args(pg2, flask.request.args)
+        assert 'op(firstname)' not in args
+        assert 'v1(firstname)' not in args
+        assert 'apply' not in flask.session['dgsessions'][pg.session_key]


### PR DESCRIPTION
- refactored args loading to the manager layer
  - although grids were abstracted from framework specifics of how to pull request args or reference the session, they were expected to know far too much about how to combine the various args sources. Grids shouldn't care about how session data is being stored.
  - now, we can just expect grids to know that they will pull args from the manager, and expect any qs_prefix issues to have been resolved already
  - introduces the concept of the ArgsLoader, which performs ops on a given set of args
    - manager has a prioritized tuple of loaders. First one gets the raw request args, and ensuing loaders are chained on the results
    - the request args loader cleans up URL args from qs_prefix, so grid can refer to args with just the natural names
    - session args loader manages load/store from cookie and override cases
- added some cleanup to session storage to prevent overflow of cookie
  - do not store empty sessions
  - do not store sessions matching an existing default session
  - remove sessions with timestamp older than 12 hours (configurable at manager level)

fixes #137 
refs #133