### PR TITLE
Resolve openpyxl imports

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-{base,i18n,stable},flake8,docs,i18n
+envlist = py{37,38,39,310}-{base,i18n,stable},flake8,docs,i18n
 
 
 [testenv]

--- a/webgrid/renderers.py
+++ b/webgrid/renderers.py
@@ -36,6 +36,8 @@ import csv
 if openpyxl:
     from openpyxl.styles import Font, Border, Side, Alignment
     from openpyxl.utils import get_column_letter
+else:
+    Font = Border = Side = Alignment = None
 
 try:
     from morphi.helpers.jinja import configure_jinja_environment

--- a/webgrid/tests/test_rendering.py
+++ b/webgrid/tests/test_rendering.py
@@ -1073,13 +1073,13 @@ class TestXLSXRenderer(object):
         assert row_values == [None, None, 'Lap 1', None, None, 'Lap 2', None, 'Lap 3', None]
         assert sheet.cell(2, 2).value == 'Label'
         assert sheet.cell(3, 2).value == 'Watch 1'
-        assert [str(range_) for range_ in sheet.merged_cells.ranges] == [
+        assert set([str(range_) for range_ in sheet.merged_cells.ranges]) == set([
             'A1:B1',
             'C1:D1',
             # E is a single cell
             'F1:G1',
             'H1:I1',
-        ]
+        ])
         assert sheet.max_column == 9
 
     def test_group_headings_xlsxwriter(self):
@@ -1095,13 +1095,13 @@ class TestXLSXRenderer(object):
         assert row_values == [None, None, 'Lap 1', None, None, 'Lap 2', None, 'Lap 3', None]
         assert sheet.cell(2, 2).value == 'Label'
         assert sheet.cell(3, 2).value == 'Watch 1'
-        assert [str(range_) for range_ in sheet.merged_cells.ranges] == [
+        assert set([str(range_) for range_ in sheet.merged_cells.ranges]) == set([
             'A1:B1',
             'C1:D1',
             # E is a single cell
             'F1:G1',
             'H1:I1',
-        ]
+        ])
         assert sheet.max_column == 9
 
     def test_subtotals_with_no_records(self):
@@ -1176,7 +1176,7 @@ class TestXLSXRenderer(object):
 
         assert sheet.max_row == 6
         assert sheet.cell(6, 1).value == 'Totals (4 records):'
-        assert sheet.merged_cells.ranges == []
+        assert set(sheet.merged_cells.ranges) == set()
 
     def test_can_render(self):
         class FakeCountsGrid(PeopleGrid):

--- a/webgrid/tests/test_types.py
+++ b/webgrid/tests/test_types.py
@@ -56,7 +56,9 @@ class TestGridSettings:
         data = self.ok_values(**input_data)
         with pytest.raises(
             types.ValidationError,
-            match=re.escape(f"{subobject}: __init__() got an unexpected keyword argument 'bar'"),
+            match=re.compile(
+                f"{subobject}:.*__init__\(\) got an unexpected keyword argument 'bar'"
+            ),
         ):
             types.GridSettings.from_dict(data)
 
@@ -64,7 +66,7 @@ class TestGridSettings:
         data = self.ok_values(sort=[{'flag_desc': False}])
         with pytest.raises(
             types.ValidationError,
-            match=re.escape("Sort: __init__() missing 1 required positional argument: 'key'"),
+            match=re.compile("Sort:.*__init__\(\) missing 1 required positional argument: 'key'"),
         ):
             types.GridSettings.from_dict(data)
 

--- a/webgrid/tests/test_types.py
+++ b/webgrid/tests/test_types.py
@@ -57,7 +57,7 @@ class TestGridSettings:
         with pytest.raises(
             types.ValidationError,
             match=re.compile(
-                f"{subobject}:.*__init__\(\) got an unexpected keyword argument 'bar'"
+                f"{subobject}:.*__init__\\(\\) got an unexpected keyword argument 'bar'"
             ),
         ):
             types.GridSettings.from_dict(data)
@@ -66,7 +66,7 @@ class TestGridSettings:
         data = self.ok_values(sort=[{'flag_desc': False}])
         with pytest.raises(
             types.ValidationError,
-            match=re.compile("Sort:.*__init__\(\) missing 1 required positional argument: 'key'"),
+            match=re.compile(r"Sort:.*__init__\(\) missing 1 required positional argument: 'key'"),
         ):
             types.GridSettings.from_dict(data)
 


### PR DESCRIPTION
Fix some undefined names when `openpyxl` is not present.

Also:
- adds python 3.10 to tox list and resolves related issues
- fixes a list/set mismatch in recent merged cell range usage

Requires #176 to pass CI. See https://app.circleci.com/pipelines/github/level12/webgrid/277/workflows/0a827b74-f33e-4b13-a077-15975401170d for a working build with both branches included.

Fixes #175 