### PR TITLE
Fix bug when rendering a filter's selected operator option

### DIFF
--- a/src/webgrid/renderers.py
+++ b/src/webgrid/renderers.py
@@ -432,7 +432,7 @@ class HTML(GroupMixin, Renderer):
     def filtering_col_op_select(self, col):
         """Render select box for filter Operator options."""
         filter = col.filter
-        current_selected = '' if filter.is_display_active else filter.op
+        current_selected = filter.op if filter.is_display_active else ''
 
         primary_op = filter.primary_op or filter.operators[0]
         is_primary = lambda op: 'primary' if op == primary_op else None

--- a/tests/webgrid_tests/test_rendering.py
+++ b/tests/webgrid_tests/test_rendering.py
@@ -786,6 +786,20 @@ class TestHtmlRenderer:
         filter_html = tg.html.filtering_fields()
         assert '<input id="search_input"' not in filter_html
 
+    @_inrequest('/thepage?op(firstname)=contains&v1(firstname)=Fred')
+    def test_filtering_operator_selected(self):
+        g = PeopleGrid()
+        g.apply_qs_args()
+
+        pyq = PyQuery(g.html())
+
+        # Ensures the op we have in the URL is valid.  If it wasn't valid, webgrid would not render
+        # a value for input1.
+        assert pyq('#firstname_input1').val() == 'Fred'
+
+        selected_opts = pyq('tr.firstname_filter td.operator option[selected]')
+        assert selected_opts.val() == 'contains'
+
 
 class PGPageTotals(PeopleGrid):
     subtotals = 'page'


### PR DESCRIPTION
Introduced when I refactored for Ruff and converted a multi-line "if" to a single line one and swapped the logic.